### PR TITLE
More tox shenanigans

### DIFF
--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -175,7 +175,7 @@ pyproj==3.3.0
     # via cartopy
 pyshp==2.1.3
     # via cartopy
-pytest==6.2.5
+pytest==7.1.3
     # via
     #   emsarray (setup.cfg)
     #   pytest-cov
@@ -240,12 +240,11 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 tblib==1.7.0
     # via distributed
-toml==0.10.2
-    # via pytest
 tomli==2.0.1
     # via
     #   coverage
     #   mypy
+    #   pytest
     #   setuptools-scm
     #   tox
 toolz==0.11.2

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,6 @@ requires =
   tox-conda
 
 [testenv]
-basepython = python3.10
-
 setenv =
 	# Conda doesn't isolate its environment from ~/.local,
 	# which can lead to strange conflicts
@@ -28,8 +26,7 @@ conda_deps =
 # Install the python dependencies through pip
 deps = -rcontinuous-integration/requirements.txt
 
-[testenv:py{38,39}-pytest]
-ignore_basepython_conflict = true
+[testenv:py{38,39,310}-pytest]
 commands =
 	pytest \
 		--junitxml=junit-{envname}.xml \
@@ -40,18 +37,22 @@ setenv =
 	EMSARRAY_DATA_DIR = {envtmpdir}/emsarray_tutorial
 
 [testenv:isort]
+basepython = python3.10
 skip_install = true
 commands = isort --diff --check-only src/ tests/
 
 [testenv:flake8]
+basepython = python3.10
 skip_install = true
 commands = flake8 src/ tests/
 
 [testenv:mypy]
+basepython = python3.10
 skip_install = true
 commands = mypy --junit-xml report-mypy.xml src/
 
 [testenv:docs]
+basepython = python3.10
 skip_install = true
 changedir = docs/
 commands = sphinx-build -b html -aEW . _build/html

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 isolated_build = true
 envlist =
 	py{38,39,310}-pytest
-	isort,flake8,mypy,docs
+	lint,docs
 skip_missing_interpreters = true
 requires =
   tox-conda
@@ -36,20 +36,13 @@ setenv =
 	{[testenv]setenv}
 	EMSARRAY_DATA_DIR = {envtmpdir}/emsarray_tutorial
 
-[testenv:isort]
+[testenv:lint]
 basepython = python3.10
 skip_install = true
-commands = isort --diff --check-only src/ tests/
-
-[testenv:flake8]
-basepython = python3.10
-skip_install = true
-commands = flake8 src/ tests/
-
-[testenv:mypy]
-basepython = python3.10
-skip_install = true
-commands = mypy --junit-xml report-mypy.xml src/
+commands =
+	isort --diff --check-only src/ tests/
+	flake8 src/ tests/
+	mypy --junit-xml report-mypy.xml src/
 
 [testenv:docs]
 basepython = python3.10


### PR DESCRIPTION
* Bumps pytest version
* ensures the correct version of python is used (basepython is tricksy)
* Collapses flake8, isort, and mypy to one tox environment