### PR TITLE
Remove explicit proj dependency

### DIFF
--- a/continuous-integration/environment.yaml
+++ b/continuous-integration/environment.yaml
@@ -3,4 +3,3 @@ channels:
 
 dependencies:
   - geos ~=3.10.2
-  - proj ~=8.2.0

--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -123,6 +123,7 @@ packaging==21.3
     #   bokeh
     #   dask
     #   distributed
+    #   emsarray (setup.cfg)
     #   matplotlib
     #   pooch
     #   pydata-sphinx-theme

--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -20,7 +20,7 @@ bokeh==2.4.2
     # via dask
 bottleneck==1.3.5
     # via emsarray (setup.cfg)
-cartopy==0.20.2
+cartopy==0.21.0
     # via emsarray (setup.cfg)
 certifi==2021.10.8
     # via
@@ -172,9 +172,9 @@ pyparsing==3.0.6
     # via
     #   matplotlib
     #   packaging
-pyproj==3.3.0
+pyproj==3.4.0
     # via cartopy
-pyshp==2.1.3
+pyshp==2.3.1
     # via cartopy
 pytest==7.1.3
     # via
@@ -204,7 +204,7 @@ scipy==1.7.3
     # via emsarray (setup.cfg)
 setuptools-scm==6.3.2
     # via matplotlib
-shapely==1.8.0
+shapely==1.8.4
     # via
     #   cartopy
     #   emsarray (setup.cfg)

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -34,29 +34,29 @@ Dependencies
 ============
 
 ``emsarray`` depends on
-`shapely <https://shapely.readthedocs.io/en/stable/project.html#installing-shapely>`_ and
-`cartopy <https://scitools.org.uk/cartopy/docs/latest/installing.html>`_.
-These use the non-Python dependencies ``geos`` and ``proj`` respectively.
+`cartopy <https://scitools.org.uk/cartopy/docs/latest/installing.html>`_
+for plotting.
+This depends on the non-Python ``geos`` library.
 
 These can be installed via your package manager or via ``conda``.
 Installing from ``conda`` is the recommended approach
 as these packages are often more up-to-date than the system packages
-and it guarantees that compatible versions of ``geos`` and ``proj`` are installed:
+and it guarantees that compatible versions of ``geos`` is installed.
 
 .. code-block:: shell-session
 
    $ conda create -n my-env
    $ conda activate my-env
-   $ conda install shapely cartopy
+   $ conda install cartopy
 
-If ``geos`` and ``proj`` are installed using your system package manager,
-and ``shapely`` and ``cartopy`` are installed via pip,
-you must ensure that you install versions of ``shapely`` and ``cartopy``
-that are compatible with these system libraries.
+If ``geos`` is installed using your system package manager,
+and ``cartopy`` is installed via pip,
+you must ensure that you install versions of ``cartopy``
+that are compatible with ``geos``.
 ``pip`` will not check for these version constraints for you.
 A version mismatch between the Python and non-Python libraries
 can lead to the installation failing,
-or Python crashing when calling ``shapely`` or ``cartopy`` functions.
+or Python crashing when calling ``cartopy`` functions.
 
 Building
 ========

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,8 @@ install_requires =
 	netcdf4 >=1.5.3
 	shapely >=1.8.0
 	xarray[parallel] >=0.18.2
-	bottleneck>=1.3
+	bottleneck >=1.3
+	packaging >=21.3
 
 [options.packages.find]
 where = src

--- a/src/emsarray/compat/shapely.py
+++ b/src/emsarray/compat/shapely.py
@@ -1,0 +1,64 @@
+import warnings
+from typing import Generic, Iterable, Tuple, TypeVar, Union, cast
+
+import numpy as np
+import shapely
+from packaging.version import parse
+from shapely.errors import ShapelyDeprecationWarning
+from shapely.geometry.base import BaseGeometry
+from shapely.strtree import STRtree
+
+shapely_version = parse(shapely.__version__)
+v2 = parse("2")
+v1_8_3 = parse("1.8.3")
+
+T = TypeVar("T")
+
+
+class SpatialIndex(Generic[T]):
+    """
+    A wrapper around a shapely STRtree that can associate metadata with
+    geometries.
+
+    This also handles the version differences in STRtree between
+    shapely ~= 1.8.x and shapely >= 2.0.0
+    """
+    items: np.ndarray
+    index: STRtree
+
+    dtype: np.dtype = np.dtype([('geom', np.object_), ('data', np.object_)])
+
+    def __init__(
+        self,
+        items: Union[np.ndarray, Iterable[Tuple[BaseGeometry, T]]],
+    ):
+        self.items = np.array(items, dtype=self.dtype)
+
+        if shapely_version >= v2:
+            self.index = STRtree(self.items['geom'])
+        elif shapely_version >= v1_8_3:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", ShapelyDeprecationWarning)
+                self.index = STRtree(geoms=self.items['geom'])
+        else:
+            self.index = STRtree(geoms=self.items['geom'])
+
+    def query(
+        self,
+        geom: BaseGeometry,
+    ) -> np.ndarray:
+        if shapely_version >= v2:
+            indices = self.index.query(geom)
+        else:
+            indices = self.index._query(geom)
+        return cast(np.ndarray, self.items.take(indices))
+
+    def nearest(
+        self,
+        geom: BaseGeometry,
+    ) -> np.ndarray:
+        if shapely_version >= v2:
+            indices = self.index.nearest(geom)
+        else:
+            indices = self.index._nearest(geom)
+        return cast(np.ndarray, self.items.take(indices))

--- a/src/emsarray/formats/arakawa_c.py
+++ b/src/emsarray/formats/arakawa_c.py
@@ -354,8 +354,9 @@ class ArakawaC(Format[ArakawaCGridKind, ArakawaCIndex]):
 
         # A cell is included if it intersects the clip polygon
         intersecting_indices = [
-            item.linear_index for item in self.spatial_index.query_items(clip_geometry)
-            if item.polygon.intersects(clip_geometry)]
+            item.linear_index
+            for polygon, item in self.spatial_index.query(clip_geometry)
+            if polygon.intersects(clip_geometry)]
         face_mask = np.full(self.face.shape, fill_value=False)
         face_mask.ravel()[intersecting_indices] = True
 

--- a/src/emsarray/formats/grid.py
+++ b/src/emsarray/formats/grid.py
@@ -257,8 +257,9 @@ class CFGrid(Generic[Topology], Format[CFGridKind, CFGridIndex]):
         topology = self.topology
 
         intersecting_indices = [
-            item.linear_index for item in self.spatial_index.query_items(clip_geometry)
-            if item.polygon.intersects(clip_geometry)]
+            item.linear_index
+            for polygon, item in self.spatial_index.query(clip_geometry)
+            if polygon.intersects(clip_geometry)]
         intersections = np.full(topology.shape, fill_value=False)
         intersections.ravel()[intersecting_indices] = True
 

--- a/src/emsarray/formats/ugrid.py
+++ b/src/emsarray/formats/ugrid.py
@@ -922,8 +922,9 @@ class UGrid(Format[UGridKind, UGridIndex]):
         # Find all faces that intersect the clip geometry
         logger.info("Making clip mask")
         intersecting_face_indices = np.array([
-            item.linear_index for item in self.spatial_index.query_items(clip_geometry)
-            if item.polygon.intersects(clip_geometry)
+            item.linear_index
+            for polygon, item in self.spatial_index.query(clip_geometry)
+            if polygon.intersects(clip_geometry)
         ])
         logger.debug("Found %d intersecting faces, adding buffer...", len(intersecting_face_indices))
 

--- a/tests/formats/test_base.py
+++ b/tests/formats/test_base.py
@@ -91,7 +91,7 @@ class SimpleFormat(Format[SimpleGridKind, SimpleGridIndex]):
     def make_clip_mask(self, clip_geometry: BaseGeometry) -> xr.Dataset:
         intersections = [
             item.linear_index
-            for item in self.spatial_index.query(clip_geometry)
+            for polygon, item in self.spatial_index.query(clip_geometry)
             if item.polygon.intersects(clip_geometry)
         ]
         cells = np.full(self.shape, False)
@@ -129,7 +129,7 @@ def test_spatial_index():
         SimpleGridIndex(3, 2), SimpleGridIndex(3, 3)}
 
     # Query the spatial index
-    items = helper.spatial_index.query_items(line)
+    items = helper.spatial_index.query(line)['data']
 
     # The exact number of items returned isn't relevant, it should just be at
     # least the total expected interesections
@@ -171,8 +171,8 @@ def test_get_index_for_point_vertex():
 
     # There should be four cells intersecting this point
     intersections = [
-        item for item in helper.spatial_index.query_items(point)
-        if item.polygon.intersects(point)
+        item for polygon, item in helper.spatial_index.query(point)
+        if polygon.intersects(point)
     ]
     assert len(intersections) == 4
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,6 @@ conda_deps =
 	pip
 	wheel
 	geos ~= 3.10.2
-	proj ~= 8.2.0
 
 # Install the python dependencies through pip
 deps = -rcontinuous-integration/requirements.txt


### PR DESCRIPTION
shapely previously depended on the proj library being installed, but this is no longer true. I think it is bundled somewhere in the dependency chain? Anyway, no point in installing it any more!