### PR TITLE
Fix readthedocs environment

### DIFF
--- a/continuous-integration/docs.yaml
+++ b/continuous-integration/docs.yaml
@@ -1,12 +1,10 @@
-name: emsarray-docs
 channels:
   - conda-forge
+
 dependencies:
-  - python=3.9
-  - pip
-  - cartopy =0.20.2
-  - shapely =1.8.0
-  - pandoc
+  - geos ~=3.10.2
+  - python =3.10
+  - wheel
   - pip:
-    - -r ../requirements.txt
+    - -r ./requirements.txt
     - -e ..


### PR DESCRIPTION
I had forgotten that there was a separate conda environment for the docs, and that it pointed to the requirements file that had moved.