### PR TITLE
Ustrse `Hashable` instead of `str` for variable and dimension names

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,16 @@
 Release notes
 =============
 
+0.3.0
+=====
+
+* Use variable and dimension names as-is, instead of casting to strings.
+  :mod:`xarray` internally treats all variable and dimension names as Hashable,
+  without assuming they are strings.
+  NetCDF4 files always use string names,
+  so this change should not affect you if you only use NetCDF4 datasets
+  (:pr:`25`).
+
 0.2.0
 =====
 

--- a/src/emsarray/formats/_base.py
+++ b/src/emsarray/formats/_base.py
@@ -240,7 +240,7 @@ class Format(abc.ABC, Generic[GridKind, Index]):
         """Get the name of the time variable in this dataset."""
         for name, variable in self.dataset.variables.items():
             if variable.attrs.get('standard_name') == 'time':
-                return str(name)
+                return name
         raise KeyError("Dataset does not have a time dimension")
 
     def get_depth_name(self) -> Hashable:
@@ -716,7 +716,7 @@ class Format(abc.ABC, Generic[GridKind, Index]):
 
         Parameters
         ----------
-        data_array : str or :class:`xarray.DataArray`, optional
+        data_array : Hashable or :class:`xarray.DataArray`, optional
             A data array, or the name of a data variable in this dataset. Optional.
             If given, the data array is :meth:`linearised <.make_linear>`
             and passed to :meth:`PatchCollection.set_array() <matplotlib.cm.ScalarMappable.set_array>`.
@@ -961,7 +961,7 @@ class Format(abc.ABC, Generic[GridKind, Index]):
         return None
 
     @abc.abstractmethod
-    def selector_for_index(self, index: Index) -> Dict[str, int]:
+    def selector_for_index(self, index: Index) -> Dict[Hashable, int]:
         """
         Convert a format native index into a selector
         that can be passed to :meth:`Dataset.isel <xarray.Dataset.isel>`.

--- a/src/emsarray/formats/shoc.py
+++ b/src/emsarray/formats/shoc.py
@@ -64,19 +64,19 @@ class ShocSimple(CFGrid2D):
     The latitude and longitude coordinate variables are named ``j`` and ``i``.
     Edge and node dimensions are dropped.
     """
-    _dimensions: Tuple[str, str] = ('j', 'i')
+    _dimensions: Tuple[Hashable, Hashable] = ('j', 'i')
 
     @cached_property
     def topology(self) -> CFGrid2DTopology:
         y_dimension, x_dimension = self._dimensions
         try:
             latitude = next(
-                str(name) for name, variable in self.dataset.variables.items()
+                name for name, variable in self.dataset.variables.items()
                 if variable.dims == self._dimensions
                 and variable.attrs["standard_name"] == "latitude"
             )
             longitude = next(
-                str(name) for name, variable in self.dataset.variables.items()
+                name for name, variable in self.dataset.variables.items()
                 if variable.dims == self._dimensions
                 and variable.attrs["standard_name"] == "longitude"
             )

--- a/src/emsarray/operations.py
+++ b/src/emsarray/operations.py
@@ -121,12 +121,12 @@ def ocean_floor(
     non_spatial_dimensions = utils.dimensions_from_coords(dataset, non_spatial_variables)
 
     for depth_dimension in sorted(depth_dimensions, key=hash):
-        dimension_sets: Dict[FrozenSet[str], List[str]] = defaultdict(list)
+        dimension_sets: Dict[FrozenSet[Hashable], List[Hashable]] = defaultdict(list)
         for name, variable in dataset.data_vars.items():
             if depth_dimension not in variable.dims:
                 continue  # Skip data variables without this depth dimension
 
-            spatial_dimensions = frozenset(map(str, variable.dims)).difference(
+            spatial_dimensions = frozenset(variable.dims).difference(
                 {depth_dimension}, non_spatial_dimensions)
             if not spatial_dimensions:
                 continue  # Skip data variables with no other spatial dimenions

--- a/src/emsarray/utils.py
+++ b/src/emsarray/utils.py
@@ -373,7 +373,7 @@ def extract_vars(
     variables = set(variables)
 
     if errors == 'raise':
-        missing_variables = variables - set(cast(Iterable[str], dataset.variables.keys()))
+        missing_variables = variables - set(dataset.variables.keys())
         if missing_variables:
             raise ValueError(
                 f"Variables {sorted(missing_variables, key=str)!r} "
@@ -478,7 +478,10 @@ def check_data_array_dimensions_match(dataset: xr.Dataset, data_array: xr.DataAr
             )
 
 
-def move_dimensions_to_end(data_array: xr.DataArray, dimensions: List[str]) -> xr.DataArray:
+def move_dimensions_to_end(
+    data_array: xr.DataArray,
+    dimensions: List[Hashable],
+) -> xr.DataArray:
     """
     Transpose the dimensions of a :class:`xarray.DataArray`
     such that the given dimensions appear as the last dimensions,
@@ -491,7 +494,7 @@ def move_dimensions_to_end(data_array: xr.DataArray, dimensions: List[str]) -> x
     ----------
     `data_array` : :class:`xarray.DataArray`
         The data array to transpose
-    `dimensions` : list of str
+    `dimensions` : list of Hashable
         The dimensions to move to the end
 
     Examples
@@ -505,12 +508,12 @@ def move_dimensions_to_end(data_array: xr.DataArray, dimensions: List[str]) -> x
         >>> transposed.dims
         ('a', 'd', 'c', 'b')
     """
-    current_dims = set(map(str, data_array.dims))
+    current_dims = set(data_array.dims)
     if not current_dims.issuperset(dimensions):
-        missing = set(dimensions) - set(current_dims)
-        raise ValueError(f"DataArray does not contain dimensions {sorted(missing)!r}")
+        missing = sorted(set(dimensions) - set(current_dims), key=str)
+        raise ValueError(f"DataArray does not contain dimensions {missing!r}")
 
-    new_order = [str(dim) for dim in data_array.dims if dim not in dimensions] + dimensions
+    new_order = [dim for dim in data_array.dims if dim not in dimensions] + dimensions
     if new_order == list(data_array.dims):
         # Don't bother transposing if the dimensions are already correct.
         return data_array.copy(deep=False)
@@ -520,8 +523,8 @@ def move_dimensions_to_end(data_array: xr.DataArray, dimensions: List[str]) -> x
 
 def linearise_dimensions(
     data_array: xr.DataArray,
-    dimensions: List[str],
-    linear_dimension: Optional[str] = None,
+    dimensions: List[Hashable],
+    linear_dimension: Optional[Hashable] = None,
 ) -> xr.DataArray:
     """
     Flatten the given dimensions of a :class:`~xarray.DataArray`.
@@ -534,10 +537,10 @@ def linearise_dimensions(
 
     `data_array` : :class:`xarray.DataArray`
         The data array to linearize
-    `dimensions` : list of str
+    `dimensions` : list of Hashable
         The dimensions to linearize, in the desired order.
         These dimensions can be in any order and any position in the input data array.
-    `linear_dimension` : str, optional
+    `linear_dimension` : Hashable, optional
         The name of the new dimension of flattened data.
         Defaults to `index`, or `index_0`, `index_1`, etc if not given.
 


### PR DESCRIPTION
This is the type exposed by xarray. NetCDF4 enforces string names, but other data types might allow different variable name types.

This actually cleans up the code by removing a whole bunch of casting.