### PR TITLE
Fix issue when UGRID `start_index` is the string "0" or "1"

### DIFF
--- a/docs/api/exceptions.rst
+++ b/docs/api/exceptions.rst
@@ -1,0 +1,6 @@
+===================
+emsarray.exceptions
+===================
+
+.. automodule:: emsarray.exceptions
+    :members:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -19,3 +19,4 @@ API reference
     utils.rst
     tutorial.rst
     plot.rst
+    exceptions.rst

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -14,7 +14,7 @@ Release notes
 * Fix error when UGRID `start_index` is the string `"0"` or `"1"`.
   The conventions imply this should be an integer type,
   however real datasets use a string value here so a tolerant implementation is useful
-  (:pr:`26`).
+  (:pr:`26`, :pr:`csiro-coasts/emsarray-data#1`).
 
 0.2.0
 =====

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -11,6 +11,10 @@ Release notes
   NetCDF4 files always use string names,
   so this change should not affect you if you only use NetCDF4 datasets
   (:pr:`25`).
+* Fix error when UGRID `start_index` is the string `"0"` or `"1"`.
+  The conventions imply this should be an integer type,
+  however real datasets use a string value here so a tolerant implementation is useful
+  (:pr:`26`).
 
 0.2.0
 =====

--- a/src/emsarray/exceptions.py
+++ b/src/emsarray/exceptions.py
@@ -1,0 +1,24 @@
+"""
+Exception and warning classes for specific exceptions
+relating to emsarray and datasets.
+"""
+
+
+class EmsarrayError(Exception):
+    """
+    Base class for all emsarray-specific exception classes.
+    """
+
+
+class ConventionViolationError(EmsarrayError):
+    """
+    A dataset violates its conventions in a way that is not recoverable.
+    """
+
+
+class ConventionViolationWarning(UserWarning):
+    """
+    A dataset violates its conventions in a way that we can handle.
+    For example, an attribute has an invalid type,
+    but is still interpretable.
+    """


### PR DESCRIPTION
Fix error when UGRID `start_index` is the string `"0"` or `"1"`. The conventions imply this should be an integer type, however real datasets use a string value here so a tolerant implementation is useful.