### PR TITLE
Release 0.3.1

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,11 @@
 Release notes
 =============
 
+0.3.1
+=====
+
+* Fixed 'Release notes' URL in ``setup.cfg`` package metadata.
+
 0.3.0
 =====
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ license_files = LICENCE
 
 project_urls =
 	Documentation = https://emsarray.readthedocs.io/
-	Release notes = https://emsarray.readthedocs.io/en/stable/releases/
+	Release notes = https://emsarray.readthedocs.io/en/stable/releases.html
 	Source = https://github.com/csiro-coasts/emsarray/
 
 [options]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = emsarray
 description = xarray extension that supports EMS model formats
-version = 0.3.0
+version = 0.3.1
 long_description = file: README.md
 long_description_content_type = text/markdown
 author = "Coastal Environmental Modelling team, Oceans and Atmosphere, CSIRO"


### PR DESCRIPTION
Messed up the 'Release notes' URL in setup.cfg, and the only way to update the PyPI metadata is to publish another version!