### PR TITLE
Manual format binding

### DIFF
--- a/docs/api/formats/ugrid.rst
+++ b/docs/api/formats/ugrid.rst
@@ -5,7 +5,7 @@ emsarray.formats.ugrid
 .. automodule:: emsarray.formats.ugrid
 
 .. autoclass:: UGrid
-    :members: topology, open_dataset
+    :members: topology
 
 Indexing
 ========

--- a/src/emsarray/formats/_base.py
+++ b/src/emsarray/formats/_base.py
@@ -21,6 +21,7 @@ from emsarray.plot import (
     _requires_plot, animate_on_figure, plot_on_figure,
     polygons_to_patch_collection
 )
+from emsarray.state import State
 from emsarray.types import Pathish
 
 if TYPE_CHECKING:
@@ -200,6 +201,52 @@ class Format(abc.ABC, Generic[GridKind, Index]):
         False
         """
         pass
+
+    def bind(self) -> None:
+        """
+        Bind this :class:`.Format` instance as the default format
+        for the :class:`xarray.Dataset`.
+        This format instance will be assigned to :attr:`dataset.ems`.
+
+        You can use a Format instance without binding it to a Dataset,
+        binding is only necessary if you need to use the :attr:`dataset.ems` accessor.
+
+        .. note::
+
+            If you use :func:`emsarray.open_dataset` or :attr:`dataset.ems`
+            to autodetect the dataset format you do not need to call this method.
+            :meth:`Format.bind` is only useful if you manually construct a :class:`Format`.
+
+        Example
+        -------
+
+        .. code-block:: python
+
+            # Open a dataset built using the GRASS format
+            dataset = xarray.open_dataset("grass-dataset.nc")
+
+            # Construct a GrassFormat instance for the dataset and bind it
+            format = GrassFormat(dataset)
+            format.bind()
+
+            # dataset.ems is now the bound format
+            assert dataset.ems is format
+
+        If the dataset already has a bound format, an error is raised.
+        To bind a new format to a dataset, make a copy of the dataset first:
+
+        .. code-block:: python
+
+            new_dataset = dataset.copy()
+            format = GrassFormat(new_dataset)
+            format.bind()
+        """
+        state = State.get(self.dataset)
+        if state.is_bound():
+            raise ValueError(
+                "A format has already been bound to this dataset, "
+                "cannot assign a new format.")
+        state.bind_format(self)
 
     def _get_data_array(self, data_array: DataArrayOrName) -> xr.DataArray:
         """

--- a/src/emsarray/formats/_base.py
+++ b/src/emsarray/formats/_base.py
@@ -142,29 +142,6 @@ class Format(abc.ABC, Generic[GridKind, Index]):
         self.dataset = dataset
 
     @classmethod
-    def open_dataset(cls, path: Pathish, **kwargs: Any) -> xr.Dataset:
-        """
-        Open the dataset at ``path``, setting any flags necessary for this format.
-
-        Parameters
-        ----------
-        path
-            The path to the dataset to open
-        kwargs
-            These are passed straight through to :func:`xarray.open_dataset`.
-
-        Returns
-        -------
-        :class:`xarray.Dataset`
-            The opened dataset
-
-        See also
-        --------
-        :func:`emsarray.open_dataset`
-        """
-        return cast(xr.Dataset, xr.open_dataset(path, **kwargs))
-
-    @classmethod
     def check_validity(cls, dataset: xr.Dataset) -> None:
         """Checks that the dataset is OK to use.
         Called during __init__, and raises exceptions if the dataset has problems.

--- a/src/emsarray/formats/_helpers.py
+++ b/src/emsarray/formats/_helpers.py
@@ -181,15 +181,16 @@ def open_dataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
     --------
     :meth:`emsarray.formats.Format.open_dataset`
     :func:`xarray.open_dataset`
-
     """
     dataset = xr.open_dataset(path, **kwargs)
-    format_class = get_file_format(dataset)
-    if format_class is None:
-        raise ValueError("Could not determine format of dataset {str(path)!r}")
+
+    # Determine the correct format. All the magic happens in the accessor.
+    format = dataset.ems
+    format_class = type(format)
     logger.debug(
         "Using format %s.%s for dataset %r",
         format_class.__module__, format_class.__name__, str(path))
+
     return dataset
 
 

--- a/src/emsarray/formats/_helpers.py
+++ b/src/emsarray/formats/_helpers.py
@@ -154,12 +154,8 @@ def get_file_format(dataset: xr.Dataset) -> Optional[Type[Format]]:
 
 def open_dataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
     """
-    Determine the format of a dataset and then open it,
-    setting any flags required by the format.
-
-    Some dataset formats require certain flags to be set when opening a dataset.
-    :func:`emsarray.open_dataset` delegates to the correct
-    :class:`~emsarray.formats.Format` implementation.
+    Open a dataset and determine the correct Format implementation for it.
+    If a valid Format implementation can not be found, an error is raised.
 
     Parameters
     ----------
@@ -188,11 +184,13 @@ def open_dataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
 
     """
     dataset = xr.open_dataset(path, **kwargs)
-    file_format = get_file_format(dataset)
-    if file_format is None:
+    format_class = get_file_format(dataset)
+    if format_class is None:
         raise ValueError("Could not determine format of dataset {str(path)!r}")
-    logger.debug("Opening dataset %r with %s", str(path), file_format.__name__)
-    return file_format.open_dataset(path, **kwargs)
+    logger.debug(
+        "Using format %s.%s for dataset %r",
+        format_class.__module__, format_class.__name__, str(path))
+    return dataset
 
 
 def entry_point_formats() -> Iterable[Type[Format]]:

--- a/src/emsarray/state.py
+++ b/src/emsarray/state.py
@@ -1,0 +1,46 @@
+"""
+Dataclass for containing state required for emsarray
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Final, Optional, cast
+
+import xarray as xr
+
+if TYPE_CHECKING:
+    from emsarray.formats._base import Format
+
+
+@dataclasses.dataclass
+class State:
+    """
+    Keeps state for emsarray.
+    Currently only used to allow binding Format instances to datasets
+    to avoid format autodetection.
+    """
+    dataset: xr.Dataset
+    format: Optional[Format] = None
+
+    accessor_name: Final[str] = "_emsarray_state"
+
+    @classmethod
+    def get(cls, dataset: xr.Dataset) -> "State":
+        """
+        Get the state for a dataset,
+        making an empty state if none exists.
+        """
+        return cast(State, getattr(dataset, State.accessor_name))
+
+    def bind_format(self, format: Format) -> None:
+        """
+        Bind a Format instance to this Dataset.
+        If the Dataset is already bound, an error is raised.
+        """
+        self.format = format
+
+    def is_bound(self) -> bool:
+        """
+        Check if the Dataset has a bound format.
+        """
+        return self.format is not None

--- a/tests/formats/test_ugrid.py
+++ b/tests/formats/test_ugrid.py
@@ -778,7 +778,7 @@ def test_one_based_indexing(datasets: pathlib.Path, tmp_path: pathlib.Path):
     Open and check a UGrid dataset that uses one-based indexing,
     as indicated by the 'start_index' attribute.
     """
-    dataset = UGrid.open_dataset(datasets / 'ugrid_mesh2d_one_indexed.nc')
+    dataset = xr.open_dataset(datasets / 'ugrid_mesh2d_one_indexed.nc')
     helper: UGrid = dataset.ems
     topology = helper.topology
 

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,0 +1,76 @@
+"""
+Test binding Format instances to datasets,
+whether implicitly through the accessor autodetection or manually.
+"""
+import pytest
+import xarray as xr
+
+import emsarray
+from emsarray.formats import CFGrid2D, ShocStandard
+from emsarray.state import State
+
+
+def test_automatic_binding_via_accessor(datasets):
+    ds = xr.open_dataset(datasets / 'cfgrid1d.nc')
+    state = State.get(ds)
+
+    # Fresh datasets opened via xarray should be unbound initially
+    assert not state.is_bound()
+    assert state.format is None
+
+    # Autodetection via the accessor should bind the format
+    format = ds.ems
+    assert state.is_bound()
+    assert state.format is format
+
+
+def test_automatic_binding_via_open_dataset(datasets):
+    ds = emsarray.open_dataset(datasets / 'cfgrid1d.nc')
+    state = State.get(ds)
+
+    # Datasets opened via emsarray.open_dataset should be bound
+    assert state.is_bound()
+    assert ds.ems is state.format
+
+
+def test_manual_binding(datasets):
+    ds = xr.open_dataset(datasets / 'shoc_standard.nc')
+    state = State.get(ds)
+
+    # Fresh datasets opened via xarray should be unbound initially
+    assert not state.is_bound()
+    assert state.format is None
+
+    # Construct a format. Autodetection would use ShocStandard,
+    # but CFGrid2D is also compatible.
+    format = CFGrid2D(ds, longitude='x_centre', latitude='y_centre')
+
+    # Merely constructing this format should not bind anything
+    assert not state.is_bound()
+    assert state.format is None
+
+    # Manually bind and check that it holds
+    format.bind()
+    assert state.is_bound()
+    assert state.format is format
+    assert ds.ems is format
+
+
+def test_copy_rebind(datasets):
+    ds_shoc = emsarray.open_dataset(datasets / 'shoc_standard.nc')
+    shoc_format = ds_shoc.ems
+    assert isinstance(shoc_format, ShocStandard)
+
+    # Binding an already bound dataset should raise an error
+    cfgrid_format = CFGrid2D(ds_shoc, longitude='x_centre', latitude='y_centre')
+    with pytest.raises(ValueError):
+        cfgrid_format.bind()
+
+    # Making a copy and binding that should work
+    ds_cfgrid = ds_shoc.copy()
+    cfgrid_format = CFGrid2D(ds_cfgrid, longitude='x_centre', latitude='y_centre')
+    cfgrid_format.bind()
+
+    # Each dataset should have its own bound format
+    assert ds_cfgrid.ems is cfgrid_format
+    assert ds_shoc.ems is shoc_format


### PR DESCRIPTION
Adds a mechanism to bypass automatic format detection.

xarray accessors like `dataset.ems` are read only and cached. They can not be manually set. Simply doing `dataset.ems = SomeFormat(dataset)` does not work, and once set a format can not be swapped out. As such, an alternate mechanism to bind formats to datasets was required. The `emsarray.state.State` class represents this. This has attributes that _are_ modifiable. A new Format instance can be constructed and bound to a dataset - this will set the `state.format` attribute. When `dataset.ems` is then accessed, the accessor will first check to see if a custom format has already been bound. If one has been, this will be used, else a new format will be constructed using the usual autodetection method.

This allows for greater flexibility and for overriding the format if autodetection fails.