### PR TITLE
Faster polygon construction using Shapely 2.0.0

### DIFF
--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -18,7 +18,7 @@ bokeh==2.4.3
     # via dask
 bottleneck==1.3.5
     # via emsarray (setup.cfg)
-cartopy==0.21.0
+cartopy==0.21.1
     # via emsarray (setup.cfg)
 certifi==2022.9.24
     # via
@@ -119,6 +119,7 @@ numpy==1.23.3
     #   netcdf4
     #   pandas
     #   pykdtree
+    #   shapely
     #   xarray
 packaging==21.3
     # via
@@ -203,7 +204,7 @@ requests==2.28.1
     # via
     #   pooch
     #   sphinx
-shapely==1.8.4
+shapely==2.0.0
     # via
     #   cartopy
     #   emsarray (setup.cfg)

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
 	netcdf4 >=1.5.3
 	numpy >=1.18.0
 	packaging >=21.3
-	shapely >=1.8.0
+	shapely >=2.0.0
 	pyshp >=2.3.0
 	xarray[parallel] >=0.18.2
 
@@ -38,7 +38,7 @@ include = emsarray*
 
 [options.extras_require]
 plot =
-	cartopy >=0.20.0
+	cartopy >=0.21.1
 	matplotlib >=3.4.3
 	pykdtree >=1.2.2
 

--- a/src/emsarray/cli/utils.py
+++ b/src/emsarray/cli/utils.py
@@ -287,8 +287,8 @@ def geometry_argument(argument_string: str) -> BaseGeometry:
     bounds_match = bounds_re.match(argument_string)
     if bounds_match is not None:
         try:
-            return box(*map(decimal.Decimal, bounds_match.groups()))
-        except (decimal.DecimalException, ValueError):
+            return box(*map(float, bounds_match.groups()))
+        except ValueError:
             pass
 
     try:
@@ -340,7 +340,7 @@ def bounds_argument(bounds_string: str) -> BaseGeometry:
     match = bounds_re.match(bounds_string)
     if match is not None:
         try:
-            return box(*map(decimal.Decimal, match.groups()))
+            return box(*map(float, match.groups()))
         except decimal.DecimalException:
             pass
     raise argparse.ArgumentTypeError("Expecting four comma separated numbers for bounds")

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -923,7 +923,9 @@ class Convention(abc.ABC, Generic[GridKind, Index]):
         --------
         :meth:`Convention.make_linear`
         """
-        mask = np.fromiter((p is not None for p in self.polygons), dtype=bool)
+        mask = np.fromiter(
+            (p is not None for p in self.polygons),
+            dtype=bool, count=self.polygons.size)
         return cast(np.ndarray, mask)
 
     @cached_property

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import json
-from decimal import Decimal
 from pathlib import Path
 from typing import Any, List
 
@@ -79,7 +78,7 @@ def test_add_verbosity_group(args: List[str], expected: int) -> None:
 
 
 def test_bounds_argument() -> None:
-    expected = box(Decimal('1.5'), Decimal('.2'), Decimal('3.'), Decimal('4'))
+    expected = box(1.5, .2, 3., 4)
     actual = utils.bounds_argument("1.5 , .2 , 3.,4")
 
     assert actual.equals(expected)
@@ -91,7 +90,7 @@ def test_bounds_argument_invalid() -> None:
 
 
 def test_geometry_argument_bounds() -> None:
-    expected = box(Decimal('1.5'), Decimal('.2'), Decimal('3.'), Decimal('4'))
+    expected = box(1.5, .2, 3., 4)
     actual = utils.geometry_argument("1.5 , .2 , 3.,4")
 
     assert actual.equals(expected)

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -89,7 +89,7 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
             else None
             for y in range(self.shape[0])
             for x in range(self.shape[1])
-        ], dtype=object)
+        ], dtype=np.object_)
 
     def make_clip_mask(
         self,


### PR DESCRIPTION
Shapely 2 exposes a [`shapely.polygons`](https://shapely.readthedocs.io/en/stable/reference/shapely.polygons.html#shapely.polygons) function which can create large numbers of polygons directly from numpy arrays. This gives a dramatic performance improvement, varying by dataset type. For UGRID I have seen the time taken to construct the polygons halve, for large CF grids the time has dropped from ~6 seconds to ~0.1 second.

This makes #40 irrelevant. This was found when investigating caching strategies. The slow down was always in constructing the polygons not in calculating vertices, and polygons still have to be constructed when loading them from the cache.