### PR TITLE
Small efficiency improvements

### DIFF
--- a/src/emsarray/cli/commands/export_geometry.py
+++ b/src/emsarray/cli/commands/export_geometry.py
@@ -9,6 +9,7 @@ import emsarray
 from emsarray.cli import BaseCommand, CommandException
 from emsarray.operations import geometry
 from emsarray.types import Pathish
+from emsarray.utils import PerfTimer
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,10 @@ class Command(BaseCommand):
         if output_format == 'auto':
             output_format = self.guess_format(output_path)
             logger.debug("Guessed output format as %r", output_format)
+
+        with PerfTimer() as t:
+            count = dataset.ems.polygons.size
+        logger.debug("Generated %d polygons in %f seconds", count, t.elapsed)
 
         try:
             writer = format_writers[output_format]

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -418,7 +418,8 @@ def test_selector_for_index(index, selector):
 def test_make_geojson_geometry():
     dataset = make_dataset(width=3)
     feature_collection = geometry.to_geojson(dataset)
-    assert len(feature_collection.features) == len(dataset.ems.polygons)
+    features = list(iter(feature_collection.features))
+    assert len(features) == len(dataset.ems.polygons)
     out = json.dumps(feature_collection)
     assert isinstance(out, str)
 

--- a/tests/operations/triangulate/test_triangulate_dataset.py
+++ b/tests/operations/triangulate/test_triangulate_dataset.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 
 import numpy as np
 import pytest
+import shapely
 import xarray as xr
 from shapely.geometry import Polygon
 
@@ -138,7 +139,7 @@ def test_triangulate_polygon():
         triangles = _triangulate_polygon(polygon)
         assert len(triangles) == len(coords) - 2
 
-        union = reduce(lambda a, b: a.union(b), triangles)
+        union = shapely.union_all(shapely.polygons(np.array(triangles)))
         assert union.equals(polygon)
 
 


### PR DESCRIPTION
* When dumping geometry to GeoJSON, Features are made in an iterator and dumped as they are generated. This saves time and memory compared to precomputing all Features, then dumping the whole list of them.
* Triangulating datasets is slightly more efficient. Some Polygons were formed and then immediately thrown after fetching their coordinates. The coordinates are passed around directly instead.
* The time taken to generate polygons when exporting geometry is logged, for the sake of benchmarking.