### PR TITLE
support for open_mfdataset

### DIFF
--- a/src/emsarray/__init__.py
+++ b/src/emsarray/__init__.py
@@ -7,14 +7,14 @@ from typing import Any
 
 from . import tutorial
 from .accessors import ems_accessor
-from .conventions import Convention, get_dataset_convention, open_dataset
+from .conventions import Convention, get_dataset_convention, open_dataset, open_mfdataset
 
 __version__ = importlib.metadata.version("emsarray")
 
 __all__ = [
     "tutorial",
     "ems_accessor",
-    "Convention", "get_dataset_convention", "open_dataset",
+    "Convention", "get_dataset_convention", "open_dataset", "open_mfdataset", 
 ]
 
 

--- a/src/emsarray/conventions/__init__.py
+++ b/src/emsarray/conventions/__init__.py
@@ -15,7 +15,7 @@ Refer to each Convention implementation for details.
 """
 from ._base import Convention, GridKind, Index, SpatialIndexItem, Specificity
 from ._registry import get_dataset_convention, register_convention
-from ._utils import open_dataset
+from ._utils import open_dataset, open_mfdataset
 from .arakawa_c import ArakawaC
 from .grid import CFGrid1D, CFGrid2D
 from .shoc import ShocSimple, ShocStandard
@@ -24,7 +24,7 @@ from .ugrid import UGrid
 __all__ = [
     "Convention", "GridKind", "Index", "SpatialIndexItem", "Specificity",
     "get_dataset_convention", "register_convention",
-    "open_dataset",
+    "open_dataset", "open_mfdataset",
     "ArakawaC",
     "CFGrid1D", "CFGrid2D",
     "ShocSimple", "ShocStandard",

--- a/src/emsarray/conventions/_utils.py
+++ b/src/emsarray/conventions/_utils.py
@@ -59,7 +59,7 @@ def open_mfdataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
     path
         The path or list of paths to the dataset to open
     kwargs
-        These are passed straight through to :func:`xarray.open_dataset`.
+        These are passed straight through to :func:`xarray.open_mfdataset`.
 
     Returns
     -------

--- a/src/emsarray/conventions/_utils.py
+++ b/src/emsarray/conventions/_utils.py
@@ -47,3 +47,45 @@ def open_dataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
         convention_class.__module__, convention_class.__name__, str(path))
 
     return dataset
+
+
+def open_mfdataset(path: Pathish, **kwargs: Any) -> xr.Dataset:
+    """
+    Open a mfdataset and determine the correct Convention implementation for it.
+    If a valid Convention implementation can not be found, an error is raised.
+
+    Parameters
+    ----------
+    path
+        The path or list of paths to the dataset to open
+    kwargs
+        These are passed straight through to :func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    xarray.Dataset
+        The opened dataset
+
+    Example
+    -------
+
+    .. code-block:: python
+
+        import emsarray
+        dataset = emsarray.open_mfdataset("./tests/datasets/ugrid_mesh2d.nc")
+
+    See also
+    --------
+    :func:`xarray.open_mfdataset`
+    """
+    dataset = xr.open_mfdataset(path, **kwargs)
+
+    # Determine the correct convention. All the magic happens in the accessor.
+    convention = dataset.ems
+    convention_class = type(convention)
+    logger.debug(
+        "Using convention %s.%s for dataset %r",
+        convention_class.__module__, convention_class.__name__, str(path))
+
+    return dataset
+


### PR DESCRIPTION
Hello, 

I just modified the source code to support the xarray function `open_mfdataset` (i.e. read in a list of NetCDF files) as I needed it for a project. I tested a build on my machine and it works well. Apologies if I made an error or there was a reason the function wasn't included. I'm new to developing packages. 

**Example**
```Python
from glob import glob
import emsarray

ds = emsarray.open_mfdataset(glob("path/to/files/*.nc"), combine='nested',
                             concat_dim="record", data_vars='minimal', 
                             compat="override", join="override",
                             coords="minimal", parallel=False)
```