### PR TITLE
Build test conda package in CI

### DIFF
--- a/.github/actions/build-python-package/action.yaml
+++ b/.github/actions/build-python-package/action.yaml
@@ -1,0 +1,36 @@
+name: Build emsarray Python package
+description: Build the emsarray Python package in both tarball and wheel formats.
+inputs:
+  python-version:
+    description: Python version to use.
+    required: true
+  artifact-name:
+    description: Name of the uploaded artifact
+    required: false
+    default: "Python package"
+
+outputs:
+  artifact-name:
+    description: Name of the uploaded artifact
+    value: ${{ inputs.artifact-name }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
+    - name: Build python package
+      shell: bash -l {0}
+      run: |
+        pip install build
+        python3 -m build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: dist

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -13,9 +13,13 @@ runs:
     - uses: actions/setup-python@v4
       with:
         cache: 'pip'
+        cache-dependency-path: |
+          continuous-integration/requirements.txt
+          continuous-integration/environment.yaml
+          setup.cfg
         python-version: ${{ inputs.python-version }}
 
-    - name: Fetch Python package
+    - name: Fetch built emsarray package
       uses: actions/download-artifact@v3
       with:
         name: "Python package"

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -39,6 +39,7 @@ runs:
         environment-file: continuous-integration/environment.yaml
         python-version: ${{ inputs.python-version }}
         channels: conda-forge
+    - shell: bash -l {0}
       run: |
         conda install -c conda-forge wheel
 

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -4,6 +4,10 @@ inputs:
   python-version:
     description: Python version to install. Used as a Conda version constraint.
     required: true
+  package-artifact-name:
+    description: Name of the emsarray Python package artifact
+    required: false
+    default: "Python package"
 
 runs:
   using: composite
@@ -22,7 +26,7 @@ runs:
     - name: Fetch built emsarray package
       uses: actions/download-artifact@v3
       with:
-        name: "Python package"
+        name: ${{ inputs.python-artifact-name }}
         path: "dist/"
 
     - name: Cache conda packages

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -21,18 +21,23 @@ runs:
         name: "Python package"
         path: "dist/"
 
-    - name: Install base Conda environment
-      uses: mamba-org/provision-with-micromamba@main
+    - name: Cache conda packages
+      uses: actions/cache@v2
       with:
-        cache-downloads: true
-        cache-env: false
-        channels: conda-forge
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-conda-${{
+          hashFiles('continuous-integration/environment.yaml') }}
+
+    - name: Install base Conda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
         environment-file: continuous-integration/environment.yaml
-        environment-name: continuous-integration
-        extra-specs: |
-          python=${{ inputs.python-version }}
-          wheel
-          pip
+        python-version: ${{ inputs.python-version }}
+        channels: conda-forge
+      run: |
+        conda install -c conda-forge wheel
+
 
     - name: Install Python packages
       shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,26 @@ jobs:
           name: Docs
           path: docs/_build/dirhtml
 
+  build_conda:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: ['build']
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: conda-forge/emsarray-feedstock
+          path: emsarray-feedstock
+      - uses: ./.github/actions/environment
+        with:
+          python-version: "3.11"
+
+      - run: |
+          conda install conda-build
+          ./scripts/build-local-conda-package.sh
+
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,7 @@ jobs:
 
   build_conda:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: ['build']
     continue-on-error: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,29 +11,17 @@ on:
 
   workflow_dispatch:
 
+env:
+  python-version: "3.11"
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      python_version: "3.11"
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
+      - uses: ./.github/actions/build-python-package
         with:
-          python-version: ${{ env.python_version }}
-          cache: 'pip'
-
-      - name: Build python package
-        shell: bash -l {0}
-        run: |
-          pip install build
-          python3 -m build
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: "Python package"
-          path: dist
+          python-version: ${{ env.python-version }}
 
   test:
     runs-on: ubuntu-latest
@@ -80,9 +68,6 @@ jobs:
       run:
         shell: bash -l {0}
 
-    env:
-      python_version: "3.11"
-
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/environment
@@ -112,7 +97,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/environment
         with:
-          python-version: "3.11"
+          python-version: ${{ env.python-version }}
 
       - run: |
           cd docs/
@@ -122,58 +107,3 @@ jobs:
         with:
           name: Docs
           path: docs/_build/dirhtml
-
-  build_conda:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    needs: ['build']
-    continue-on-error: true
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
-        with:
-          repository: conda-forge/emsarray-feedstock
-          path: emsarray-feedstock
-      - uses: ./.github/actions/environment
-        with:
-          python-version: "3.11"
-
-      - run: |
-          conda install conda-build
-          ./scripts/build-local-conda-package.sh
-
-  publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: ['test', 'lint', 'docs']
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
-    steps:
-      - name: Fetch Python package
-        uses: actions/download-artifact@v3
-        with:
-          name: "Python package"
-          path: "dist"
-
-      - name: "Check tag matches version"
-        shell: bash -l {0}
-        run: |
-          VERSION="$( echo "${{ github.ref }}" | sed 's!refs/tags/v!!' )"
-          echo "Looking for packages with version $VERSION"
-          ls -l dist/*
-          packages=(
-            "dist/emsarray-$VERSION.tar.gz"
-            "dist/emsarray-$VERSION-*.whl"
-          )
-          for package in "${packages[@]}" ; do
-            if ! test -e $package ; then
-              echo "Could not find $package"
-              exit 1
-            fi
-          done
-
-      - name: "Publish Python package"
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,40 @@
+name: Prerelease checks
+on:
+  pull_request:
+    branches:
+      - "release-"
+
+  workflow_dispatch:
+
+env:
+  python-version: "3.11"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build-python-package
+        with:
+          python-version: ${{ env.python-version }}
+
+  build_conda:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: ['build']
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: conda-forge/emsarray-feedstock
+          path: emsarray-feedstock
+
+      - uses: ./.github/actions/environment
+        with:
+          python-version: ${{ env.python-version }}
+
+      - run: |
+          conda install conda-build
+          ./scripts/build-local-conda-package.sh

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,48 @@
+name: Publish a new version to PyPI
+on:
+  push:
+    tags:
+      - "v[0-9]+.*"
+
+  workflow_dispatch:
+
+env:
+  python-version: "3.11"
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yaml
+
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Fetch Python package
+        uses: actions/download-artifact@v3
+        with:
+          name: "Python package"
+          path: "dist"
+
+      - name: "Check tag matches version"
+        shell: bash -l {0}
+        run: |
+          VERSION="$( echo "${{ github.ref }}" | sed 's!refs/tags/v!!' )"
+          echo "Looking for packages with version $VERSION"
+          ls -l dist/*
+          packages=(
+            "dist/emsarray-$VERSION.tar.gz"
+            "dist/emsarray-$VERSION-*.whl"
+          )
+          for package in "${packages[@]}" ; do
+            if ! test -e $package ; then
+              echo "Could not find $package"
+              exit 1
+            fi
+          done
+
+      - name: "Publish Python package"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/scripts/build-local-conda-package.sh
+++ b/scripts/build-local-conda-package.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Build a conda package from the locally build python package.
+# This is used in CI to test that the conda package can be built successfully.
+#
+# Prerequisites:
+# - Python package builds at ./dist/emsarray-X.Y.Z.tar.gz
+# - conda-forge/emsarray-feedstock cloned at ./emsarray-feedstock
+
+set -euo pipefail
+
+HERE="$( cd -- "$( dirname -- "$( realpath -- "$0" )" )" && pwd )"
+PROJECT="$( dirname -- "$HERE" )"
+
+dist_path="$PROJECT/dist"
+feedstock_path="$PROJECT/emsarray-feedstock"
+
+files_to_clean=()
+
+function main() {
+	trap cleanup EXIT
+
+	local package_path="$( get_package_path )"
+	local package_name="$( basename -- "$package_path")"
+	local package_version=$( get_package_version "$package_name" )
+
+	tmp_dir="$( mktemp -d --tmpdir "emsarray-conda-build.XXXXXXX" )"
+	files_to_clean+=( "$tmp_dir" )
+	cd "$tmp_dir"
+
+	cp -R "$feedstock_path/recipe" "$tmp_dir/recipe"
+	recipe_path="$tmp_dir/recipe/meta.yaml"
+	update_recipe "$recipe_path" "$package_path" "$package_version"
+
+	cat "$recipe_path"
+
+	conda build \
+		--override-channels \
+		--channel conda-forge \
+		"$tmp_dir"
+}
+
+function get_package_path() {
+	find "$dist_path" -name 'emsarray-*.tar.gz' -print -quit
+}
+
+function get_package_version() {
+	local package_name="$1"
+	local package_version=$(
+		echo "$package_name" \
+		| sed 's/^emsarray-\(.*\)\.tar\.gz/\1/'
+	)
+	if [[ "$package_name" == "$package_version" ]] ; then
+		echo "Could not extract version from package name!"
+		exit 1
+	fi
+	echo "$package_version"
+}
+
+function update_recipe() {
+	local recipe_path="$1"
+	local package_path="$2"
+	local package_version="$3"
+
+	sed \
+		-e 's!set version = ".*"!set version = "'"$package_version"'"!' \
+		-e 's!url: https://pypi.io/.*!url: "file://'"$package_path"'"!' \
+		-e '/sha256:/d' \
+		-i "$recipe_path"
+}
+
+function cleanup() {
+	rm -rf "${files_to_clean[@]}"
+}
+
+main


### PR DESCRIPTION
This test should hopefully catch conda-forge packaging issues before release, to prevent the 0.4.0 release issue happening again (see #63)