### PR TITLE
Split CI workflows

### DIFF
--- a/.github/actions/build-python-package/action.yaml
+++ b/.github/actions/build-python-package/action.yaml
@@ -33,4 +33,4 @@ runs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.artifact-name }}
-        path: dist
+        path: "dist/"

--- a/.github/actions/build-python-package/action.yaml
+++ b/.github/actions/build-python-package/action.yaml
@@ -1,0 +1,36 @@
+name: Build emsarray Python package
+description: Build the emsarray Python package in both tarball and wheel formats.
+inputs:
+  python-version:
+    description: Python version to use.
+    required: true
+  artifact-name:
+    description: Name of the uploaded artifact
+    required: false
+    default: "Python package"
+
+outputs:
+  artifact-name:
+    description: Name of the uploaded artifact
+    value: ${{ inputs.artifact-name }}
+
+runs:
+  using: composite
+
+  steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
+    - name: Build python package
+      shell: bash -l {0}
+      run: |
+        pip install build
+        python3 -m build
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: dist

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: Fetch built emsarray package
       uses: actions/download-artifact@v3
       with:
-        name: ${{ inputs.python-artifact-name }}
+        name: ${{ inputs.package-artifact-name }}
         path: "dist/"
 
     - name: Cache conda packages

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -4,6 +4,10 @@ inputs:
   python-version:
     description: Python version to install. Used as a Conda version constraint.
     required: true
+  package-artifact-name:
+    description: Name of the emsarray Python package artifact
+    required: false
+    default: "Python package"
 
 runs:
   using: composite
@@ -13,26 +17,36 @@ runs:
     - uses: actions/setup-python@v4
       with:
         cache: 'pip'
+        cache-dependency-path: |
+          continuous-integration/requirements.txt
+          continuous-integration/environment.yaml
+          setup.cfg
         python-version: ${{ inputs.python-version }}
 
-    - name: Fetch Python package
+    - name: Fetch built emsarray package
       uses: actions/download-artifact@v3
       with:
-        name: "Python package"
+        name: ${{ inputs.python-artifact-name }}
         path: "dist/"
 
-    - name: Install base Conda environment
-      uses: mamba-org/provision-with-micromamba@main
+    - name: Cache conda packages
+      uses: actions/cache@v2
       with:
-        cache-downloads: true
-        cache-env: false
-        channels: conda-forge
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-conda-${{
+          hashFiles('continuous-integration/environment.yaml') }}
+
+    - name: Install base Conda environment
+      uses: conda-incubator/setup-miniconda@v2
+      with:
         environment-file: continuous-integration/environment.yaml
-        environment-name: continuous-integration
-        extra-specs: |
-          python=${{ inputs.python-version }}
-          wheel
-          pip
+        python-version: ${{ inputs.python-version }}
+        channels: conda-forge
+    - shell: bash -l {0}
+      run: |
+        conda install -c conda-forge wheel
+
 
     - name: Install Python packages
       shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,29 +11,20 @@ on:
 
   workflow_dispatch:
 
+env:
+  python-version: "3.11"
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      python_version: "3.11"
+    outputs:
+      artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions/setup-python@v4
+      - uses: ./.github/actions/build-python-package
+        id: build
         with:
-          python-version: ${{ env.python_version }}
-          cache: 'pip'
-
-      - name: Build python package
-        shell: bash -l {0}
-        run: |
-          pip install build
-          python3 -m build
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: "Python package"
-          path: dist
+          python-version: ${{ env.python-version }}
 
   test:
     runs-on: ubuntu-latest
@@ -50,6 +41,7 @@ jobs:
       - uses: ./.github/actions/environment
         with:
           python-version: ${{ matrix.python-version }}
+          package-artifact-name: ${{ needs.build.outputs.artifact-name }}
 
       - name: Run tests
         shell: bash -l {0}
@@ -80,20 +72,18 @@ jobs:
       run:
         shell: bash -l {0}
 
-    env:
-      python_version: "3.11"
-
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/environment
         with:
-          python-version: ${{ env.python_version }}
+          python-version: ${{ env.python-version }}
+          package-artifact-name: ${{ needs.build.outputs.artifact-name }}
 
       - name: 'mypy cache'
         uses: actions/cache@v3
         with:
           path: '.mypy_cache'
-          key: mypy-${{ runner.os }}-py${{ env.python_version }}-${{ hashFiles('requirements.txt') }}
+          key: mypy-${{ runner.os }}-py${{ env.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - run: flake8 src/ tests/
       - run: isort --diff --check-only src/ tests/
@@ -112,7 +102,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/environment
         with:
-          python-version: "3.11"
+          python-version: ${{ env.python-version }}
+          package-artifact-name: ${{ needs.build.outputs.artifact-name }}
 
       - run: |
           cd docs/
@@ -126,14 +117,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: ['test', 'lint', 'docs']
+    needs: ['build', 'test', 'lint', 'docs']
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 
     steps:
       - name: Fetch Python package
         uses: actions/download-artifact@v3
         with:
-          name: "Python package"
+          name: ${{ needs.build.outputs.artifact-name }}
           path: "dist"
 
       - name: "Check tag matches version"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,38 +113,3 @@ jobs:
         with:
           name: Docs
           path: docs/_build/dirhtml
-
-  publish:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    needs: ['build', 'test', 'lint', 'docs']
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-
-    steps:
-      - name: Fetch Python package
-        uses: actions/download-artifact@v3
-        with:
-          name: ${{ needs.build.outputs.artifact-name }}
-          path: "dist"
-
-      - name: "Check tag matches version"
-        shell: bash -l {0}
-        run: |
-          VERSION="$( echo "${{ github.ref }}" | sed 's!refs/tags/v!!' )"
-          echo "Looking for packages with version $VERSION"
-          ls -l dist/*
-          packages=(
-            "dist/emsarray-$VERSION.tar.gz"
-            "dist/emsarray-$VERSION-*.whl"
-          )
-          for package in "${packages[@]}" ; do
-            if ! test -e $package ; then
-              echo "Could not find $package"
-              exit 1
-            fi
-          done
-
-      - name: "Publish Python package"
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -1,0 +1,44 @@
+name: Prerelease checks
+on:
+  pull_request:
+    branches:
+      - "release-*"
+
+  workflow_dispatch:
+
+env:
+  python-version: "3.11"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.build.outputs.artifact-name }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build-python-package
+        id: build
+        with:
+          python-version: ${{ env.python-version }}
+
+  build_conda:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: ['build']
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: conda-forge/emsarray-feedstock
+          path: emsarray-feedstock
+
+      - uses: ./.github/actions/environment
+        with:
+          python-version: ${{ env.python-version }}
+          package-artifact-name: ${{ needs.build.outputs.artifact-name }}
+
+      - run: |
+          conda install conda-build
+          ./scripts/build-local-conda-package.sh

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -1,0 +1,56 @@
+name: Publish a new version to PyPI
+on:
+  push:
+    tags:
+      - "v[0-9]+.*"
+
+  workflow_dispatch:
+
+env:
+  python-version: "3.11"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.build.outputs.artifact-name }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/build-python-package
+        id: build
+        with:
+          python-version: ${{ env.python-version }}
+
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: ['build']
+
+    steps:
+      - name: Fetch Python package
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ needs.build.outputs.artifact-name }}
+          path: "dist"
+
+      - name: "Check tag matches version"
+        shell: bash -l {0}
+        run: |
+          VERSION="$( echo "${{ github.ref }}" | sed 's!refs/tags/v!!' )"
+          echo "Looking for packages with version $VERSION"
+          ls -l dist/*
+          packages=(
+            "dist/emsarray-$VERSION.tar.gz"
+            "dist/emsarray-$VERSION-*.whl"
+          )
+          for package in "${packages[@]}" ; do
+            if ! test -e $package ; then
+              echo "Could not find $package"
+              exit 1
+            fi
+          done
+
+      - name: "Publish Python package"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Three workflows for the different stages required:

* Regular CI job that runs the tests and lints the code for every pull request
* A prerelease CI job that runs additional checks for `release-*` branches
* A publish CI job that builds and publishes a new package from tagged commits