### PR TITLE
Enable all flake8 errors and warnings by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -80,4 +80,5 @@ emsarray.conventions =
 # emsarray.conventions end - marker used by docs
 
 [flake8]
+extend-select = E,W
 extend-ignore = E501,W503

--- a/src/emsarray/plot.py
+++ b/src/emsarray/plot.py
@@ -57,7 +57,7 @@ def add_coast(axes: Axes, **kwargs: Any) -> None:
         **kwargs,
     }
     coast = GSHHSFeature()
-    axes.add_feature(coast,  **kwargs)
+    axes.add_feature(coast, **kwargs)
 
 
 def add_gridlines(axes: Axes) -> gridliner.Gridliner:

--- a/tests/conventions/test_cfgrid1d.py
+++ b/tests/conventions/test_cfgrid1d.py
@@ -101,10 +101,10 @@ def make_dataset(
         dims=[time_name, latitude_name, longitude_name],
         name="eta",
         attrs={
-                "units": "metre",
-                "long_name": "Surface elevation",
-                "standard_name": "sea_surface_height_above_geoid",
-            }
+            "units": "metre",
+            "long_name": "Surface elevation",
+            "standard_name": "sea_surface_height_above_geoid",
+        },
     )
     temp = xr.DataArray(
         data=np.random.normal(12, 0.5, (time_size, depth, height, width)),

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -40,7 +40,7 @@ def make_faces(width: int, height, fill_value: int) -> Tuple[np.ndarray, np.ndar
     square_edges = 2 * square_rows * square_columns + square_rows + square_columns
     total_edges = triangle_edges + square_edges - width
 
-    face_node = np.ma.masked_array(
+    face_node: np.ndarray = np.ma.masked_array(
         np.full((total_faces, 4), fill_value, dtype=np.int32),
         mask=True, fill_value=fill_value)
     edge_node = np.zeros((total_edges, 2), dtype=np.int32)
@@ -223,10 +223,10 @@ def make_dataset(
         dims=[time_dimension, face_dimension],
         name="eta",
         attrs={
-                "units": "metre",
-                "long_name": "Surface elevation",
-                "standard_name": "sea_surface_height_above_geoid",
-            }
+            "units": "metre",
+            "long_name": "Surface elevation",
+            "standard_name": "sea_surface_height_above_geoid",
+        },
     )
     temp = xr.DataArray(
         data=np.random.normal(12, 0.5, (time_size, depth_size, cell_size)),


### PR DESCRIPTION
I noticed this because of some bad styles that were not being picked up. Some digging showed that some checks were disabled by default because they are not strictly mentioned in PEP8. I enabled all the checks by default, we can choose to disable specific ones if required in the future.