### PR TITLE
Add `emsarray plot` subcommand

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -81,3 +81,25 @@ Extract the data at some points given in a CSV file:
     $ emsarray extract-points gbr4.nc gbr4-points.csv gbr4-points.nc
 
 See ``emsarray extract-points --help`` for a full list of options.
+
+``emsarray plot``
+-----------------
+
+Render a simple plot of the dataset geometry, or of one variable.
+Call with just a dataset path to plot the dataset geometry.
+
+.. code-block:: shell-session
+
+   # Plot the geometry of the dataset
+   $ emsarray plot gbr4.nc
+
+Plot a single variable by passing its name as the second argument.
+You may have to select a single index from any extra dimensions,
+such as time and depth.
+Use the ``--sel`` or ``--isel`` flags for this,
+which will be passed to :meth:`xarray.Dataset.sel` and :meth:`xarray.Dataset.isel` respectively:
+
+.. code-block:: shell-session
+
+   # Plot the surface temperature at the first timestep
+   $ emsarray plot gbr4.nc temp --isel k=-1 --isel record=0

--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -3,3 +3,4 @@ Next release (in development)
 =============================
 
 * Fix an issue with negative coordinates in :func:`~emsarray.cli.utils.bounds_argument` (:pr:`74`).
+* Add a new ``emsarray plot`` subcommand to the ``emsarray`` command line interface (:pr:`76`).

--- a/src/emsarray/cli/commands/plot.py
+++ b/src/emsarray/cli/commands/plot.py
@@ -1,0 +1,92 @@
+import argparse
+import functools
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Text, TypeVar
+
+import emsarray
+from emsarray.cli import BaseCommand, CommandException
+
+T = TypeVar('T')
+
+logger = logging.getLogger(__name__)
+
+
+def key_value(arg: str, value_type: Callable = str) -> Dict[str, T]:
+    try:
+        name, value = arg.split("=", 2)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            "Coordinate / dimension indexes must be given as `name=value` pairs")
+    return {name: value_type(value)}
+
+
+class UpdateDict(argparse.Action):
+    def __init__(
+        self,
+        option_strings: List[str],
+        dest: str,
+        *,
+        value_type: Callable = str,
+        default: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        if default is None:
+            default = {}
+        type = functools.partial(key_value, value_type=value_type)
+        super().__init__(
+            option_strings, dest, default=default, type=type, **kwargs)
+
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: Any,
+        option_string: Optional[Text] = None,
+    ) -> None:
+        super().__call__
+        holder = getattr(namespace, self.dest, {})
+        print(namespace, holder, values, option_string)
+        holder.update(values)
+        setattr(namespace, self.dest, holder)
+
+
+class Command(BaseCommand):
+    help = "Plot a dataset variable"
+
+    def add_arguments(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "input_path", type=Path,
+            help="Path to input netCDF4 file")
+        parser.add_argument(
+            "variable", type=str, nargs='?', default=None,
+            help="Name of a variable to plot")
+        parser.add_argument(
+            "-s", "--sel", action=UpdateDict,
+            help="Select a single coordinate value")
+        parser.add_argument(
+            "-i", "--isel", action=UpdateDict, value_type=int,
+            help="Select a single dimension index")
+
+    def handle(self, options: argparse.Namespace) -> None:
+        dataset = emsarray.open_dataset(options.input_path)
+        convention: emsarray.Convention = dataset.ems
+
+        if options.variable is None:
+            logger.info("Plotting %r", str(options.input_path))
+            data_array = None
+        else:
+            variable_name = options.variable
+            if variable_name not in dataset.variables:
+                raise CommandException(f"Dataset has no variable {variable_name!r}")
+            data_array = dataset[variable_name]
+
+            logger.info("Plotting %r of %r", variable_name, str(options.input_path))
+
+            logger.debug("data_array %s", data_array)
+            if options.sel:
+                data_array = data_array.sel(options.sel)
+            if options.isel:
+                data_array = data_array.isel(options.isel)
+
+        convention.plot(data_array)

--- a/src/emsarray/plot.py
+++ b/src/emsarray/plot.py
@@ -61,7 +61,7 @@ def add_coast(axes: Axes, **kwargs: Any) -> None:
 
 
 def add_gridlines(axes: Axes) -> gridliner.Gridliner:
-    gridlines = axes.gridlines(draw_labels=True)
+    gridlines = axes.gridlines(draw_labels=True, auto_update=True)
     gridlines.top_labels = False
     gridlines.right_labels = False
     return gridlines

--- a/tests/cli/commands/test_plot.py
+++ b/tests/cli/commands/test_plot.py
@@ -1,0 +1,41 @@
+import pathlib
+from unittest import mock
+
+import pytest
+import xarray
+
+from emsarray import Convention
+from emsarray.cli import main
+
+
+@pytest.mark.matplotlib
+def test_plot_geometry(
+    datasets: pathlib.Path,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_path = datasets / 'ugrid_mesh2d.nc'
+
+    with mock.patch.object(Convention, 'plot') as plot_mock:
+        main(['plot', str(dataset_path)])
+
+    plot_mock.assert_called_once_with(None)
+
+
+@pytest.mark.matplotlib
+def test_plot_values(
+    datasets: pathlib.Path,
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset_path = datasets / 'ugrid_mesh2d.nc'
+
+    with mock.patch.object(Convention, 'plot') as plot_mock:
+        main(['plot', str(dataset_path), 'values'])
+
+    args, kwargs = plot_mock.call_args
+    values = args[0]
+    plot_mock.assert_called_once_with(values)
+    assert isinstance(values, xarray.DataArray)
+    assert values.name == 'values'
+    assert values.dims == ('face',)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pathlib
+from unittest import mock
 
 import pytest
 
@@ -17,13 +18,22 @@ def pytest_runtest_setup(item):
 
 
 @pytest.fixture
-def matplotlib_backend(backend='template'):
+def matplotlib_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str = 'template',
+):
     """
     Override the matplotlib backend for this test to 'template'
     """
     import matplotlib
+    import matplotlib.pyplot
+
+    show_mock = mock.Mock(spec=matplotlib.pyplot.show)
+    monkeypatch.setattr(matplotlib.pyplot, 'show', show_mock)
+
     with matplotlib.rc_context({'backend': 'template'}):
         yield
+        matplotlib.pyplot.close('all')
 
 
 def _needs_tutorial_mark(*args, **kwargs):

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -5,6 +5,7 @@ import enum
 from functools import cached_property
 from typing import Dict, Hashable, List, Optional, Tuple
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 import xarray as xr
@@ -282,15 +283,21 @@ def test_plot():
 
     # Naming a simple variable should work fine
     convention.plot('botz')
+    plt.show.assert_called_once()
+    plt.show.reset_mock()
 
     # This should raise an error, as 'temp' is 3D + time
     temp = dataset.data_vars['temp']
     with pytest.raises(ValueError):
         convention.plot(temp)
+    plt.show.assert_not_called()
+    plt.show.reset_mock()
 
     # Slice off the surface, at one time point
     initial_surface_temp = temp.isel({'z': 0, 't': 0})
     convention.plot(initial_surface_temp)
+    plt.show.assert_called_once()
+    plt.show.reset_mock()
 
 
 def test_face_centres():


### PR DESCRIPTION
Useful for quickly examining a dataset in an interactive environment. Making matplotlib patches is painfully slow, so this is not useful for large datasets with many cells.