### PR TITLE
Use PolyCollection over PatchCollection in matplotlib plots

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -4,3 +4,7 @@ Next release (in development)
 
 * Fix an issue with negative coordinates in :func:`~emsarray.cli.utils.bounds_argument` (:pr:`74`).
 * Add a new ``emsarray plot`` subcommand to the ``emsarray`` command line interface (:pr:`76`).
+* Use :class:`matplotlib.collections.PolyCollection`
+  rather than :class:`~matplotlib.collections.PatchCollection`
+  for significant speed improvements
+  (:pr:`77`).

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -325,28 +325,28 @@ def test_face_centres():
 
 
 @pytest.mark.matplotlib
-def test_make_patch_collection():
+def test_make_poly_collection():
     dataset = xr.Dataset({
         'temp': (['t', 'z', 'y', 'x'], np.random.standard_normal((5, 5, 10, 20))),
         'botz': (['y', 'x'], np.random.standard_normal((10, 20)) - 10),
     })
     convention = SimpleConvention(dataset)
 
-    patches = convention.make_patch_collection(cmap='plasma', edgecolor='black')
+    patches = convention.make_poly_collection(cmap='plasma', edgecolor='black')
     assert len(patches.get_paths()) == len(convention.polygons[convention.mask])
     assert patches.get_cmap().name == 'plasma'
     # Colours get transformed in to RGBA arrays
     np.testing.assert_equal(patches.get_edgecolor(), [[0., 0., 0., 1.0]])
 
 
-def test_make_patch_collection_data_array():
+def test_make_poly_collection_data_array():
     dataset = xr.Dataset({
         'temp': (['t', 'z', 'y', 'x'], np.random.standard_normal((5, 5, 10, 20))),
         'botz': (['y', 'x'], np.random.standard_normal((10, 20)) - 10),
     })
     convention = SimpleConvention(dataset)
 
-    patches = convention.make_patch_collection(data_array='botz')
+    patches = convention.make_poly_collection(data_array='botz')
     assert len(patches.get_paths()) == len(convention.polygons[convention.mask])
 
     values = convention.make_linear(dataset.data_vars['botz'])[convention.mask]
@@ -354,7 +354,7 @@ def test_make_patch_collection_data_array():
     assert patches.get_clim() == (np.nanmin(values), np.nanmax(values))
 
 
-def test_make_patch_collection_data_array_and_array():
+def test_make_poly_collection_data_array_and_array():
     dataset = xr.Dataset({
         'temp': (['t', 'z', 'y', 'x'], np.random.standard_normal((5, 5, 10, 20))),
         'botz': (['y', 'x'], np.random.standard_normal((10, 20)) - 10),
@@ -365,10 +365,10 @@ def test_make_patch_collection_data_array_and_array():
 
     with pytest.raises(TypeError):
         # Passing both array and data_array is a TypeError
-        convention.make_patch_collection(data_array='botz', array=array)
+        convention.make_poly_collection(data_array='botz', array=array)
 
 
-def test_make_patch_collection_data_array_and_clim():
+def test_make_poly_collection_data_array_and_clim():
     dataset = xr.Dataset({
         'temp': (['t', 'z', 'y', 'x'], np.random.standard_normal((5, 5, 10, 20))),
         'botz': (['y', 'x'], np.random.standard_normal((10, 20)) - 10),
@@ -376,11 +376,11 @@ def test_make_patch_collection_data_array_and_clim():
     convention = SimpleConvention(dataset)
 
     # You can override the default clim if you want
-    patches = convention.make_patch_collection(data_array='botz', clim=(-12, -8))
+    patches = convention.make_poly_collection(data_array='botz', clim=(-12, -8))
     assert patches.get_clim() == (-12, -8)
 
 
-def test_make_patch_collection_data_array_dimensions():
+def test_make_poly_collection_data_array_dimensions():
     dataset = xr.Dataset({
         'temp': (['t', 'z', 'y', 'x'], np.random.standard_normal((5, 5, 10, 20))),
         'botz': (['y', 'x'], np.random.standard_normal((10, 20)) - 10),
@@ -389,12 +389,12 @@ def test_make_patch_collection_data_array_dimensions():
 
     with pytest.raises(ValueError):
         # temp needs subsetting first, so this should raise an error
-        convention.make_patch_collection(data_array='temp')
+        convention.make_poly_collection(data_array='temp')
 
     # One way to avoid this is to isel the data array
-    convention.make_patch_collection(data_array=dataset.data_vars['temp'].isel(z=0, t=0))
+    convention.make_poly_collection(data_array=dataset.data_vars['temp'].isel(z=0, t=0))
 
     # Another way to avoid this is to isel the dataset
     dataset_0 = dataset.isel(z=0, t=0)
     convention = SimpleConvention(dataset_0)
-    convention.make_patch_collection(data_array='temp')
+    convention.make_poly_collection(data_array='temp')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -2,26 +2,17 @@ import numpy as np
 import pytest
 from shapely.geometry import Polygon
 
-from emsarray.plot import polygon_to_patch, polygons_to_patch_collection
+from emsarray.plot import polygons_to_collection
 
 
 @pytest.mark.matplotlib
-def test_polygon_to_patch():
-    polygon = Polygon([(0, 0), (1, 0), (2, 2,), (0, 1), (0, 0)])
-    patch = polygon_to_patch(polygon)
-    for index, poly_coords in enumerate(polygon.exterior.coords):
-        patch_coords = patch.get_xy()[index]
-        assert tuple(poly_coords) == tuple(patch_coords)
-
-
-@pytest.mark.matplotlib
-def test_polygons_to_patch_collection():
+def test_polygons_to_collection():
     polygons = [
         Polygon([(i, 0), (i + 1, 0), (i + 1, 1), (i, 1), (i, 0)])
         for i in range(10)
     ]
     data = np.random.random(10) * 10
-    patch_collection = polygons_to_patch_collection(
+    patch_collection = polygons_to_collection(
         polygons, array=data, cmap='autumn', clim=(0, 10))
 
     # Check that the polygons came through


### PR DESCRIPTION
It is significantly faster! Doesn't seem to be any down sides. I had previously dismissed it as I didn't think it supported polygons with different numbers of vertices, but that was because I had read the docs incorrectly.

`Convention.make_patch_collection()` is now deprecated, and is an alias for `Convention.make_poly_collection()`. Unless a user is specifically expecting a PatchCollection everything should continue to work - the two classes take most of their functionality from the common underlying `Collection` class.