### PR TITLE
Add Convention.geometry and Convention.bounds

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -9,3 +9,4 @@ Next release (in development)
   for significant speed improvements
   (:pr:`77`).
 * Added :func:`emsarray.utils.timed_func` for easily logging some performance metrics (:pr:`79`).
+* Add :attr:`.Convention.bounds` and :attr:`.Convention.geometry` attributes (:pr:`83`).

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -29,7 +29,7 @@ from emsarray import utils
 from emsarray.exceptions import (
     ConventionViolationError, ConventionViolationWarning
 )
-from emsarray.types import Pathish
+from emsarray.types import Bounds, Pathish
 
 from ._base import Convention, Specificity
 
@@ -1102,6 +1102,15 @@ class UGrid(Convention[UGridKind, UGridIndex]):
             face_centres = np.column_stack((face_x, face_y))
             return cast(np.ndarray, face_centres)
         return super().face_centres
+
+    @cached_property
+    def bounds(self) -> Bounds:
+        topology = self.topology
+        min_x = np.nanmin(topology.node_x)
+        max_x = np.nanmax(topology.node_x)
+        min_y = np.nanmin(topology.node_y)
+        max_y = np.nanmax(topology.node_y)
+        return (min_x, min_y, max_x, max_y)
 
     def selector_for_index(self, index: UGridIndex) -> Dict[Hashable, int]:
         kind, i = index

--- a/src/emsarray/types.py
+++ b/src/emsarray/types.py
@@ -1,6 +1,7 @@
 """Collection of type aliases used across the library."""
 
 import os
-from typing import Union
+from typing import Tuple, Union
 
 Pathish = Union[os.PathLike, str]
+Bounds = Tuple[float, float, float, float]

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -17,6 +17,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 from matplotlib.figure import Figure
+from numpy.testing import assert_allclose
 from shapely.geometry import Polygon
 from shapely.testing import assert_geometries_equal
 
@@ -24,7 +25,10 @@ from emsarray.conventions import get_dataset_convention
 from emsarray.conventions.grid import CFGridKind
 from emsarray.conventions.shoc import ShocSimple
 from emsarray.operations import geometry
-from tests.utils import DiagonalShocGrid, ShocGridGenerator, ShocLayerGenerator
+from tests.utils import (
+    DiagonalShocGrid, ShocGridGenerator, ShocLayerGenerator,
+    assert_property_not_cached
+)
 
 
 def make_dataset(
@@ -232,6 +236,14 @@ def test_holes():
     # A polygon surrounded by all neighbours is full sized
     poly = only_polygons[22]
     assert poly.equals_exact(Polygon([(0.3, 1.9), (0.4, 1.8), (0.5, 1.9), (0.4, 2.0), (0.3, 1.9)]), 1e-6)
+
+
+def test_bounds():
+    dataset = make_dataset(
+        j_size=10, i_size=20, corner_size=5, include_bounds=True)
+    # The corner cuts out some of the upper bounds
+    assert_allclose(dataset.ems.bounds, (0, 0, 3, 2.5))
+    assert_property_not_cached(dataset.ems, 'geometry')
 
 
 def test_face_centres():

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -23,6 +23,7 @@ from emsarray.exceptions import (
     ConventionViolationError, ConventionViolationWarning
 )
 from emsarray.operations import geometry
+from tests.utils import assert_property_not_cached
 
 
 def make_faces(width: int, height, fill_value: int) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -399,6 +400,15 @@ def test_face_centres_from_centroids():
         polygon = convention.polygons[linear_index]
         lon, lat = polygon.centroid.coords[0]
         np.testing.assert_equal(face_centres[linear_index], [lon, lat])
+
+
+def test_bounds(datasets: pathlib.Path):
+    dataset = xr.open_dataset(datasets / 'ugrid_mesh2d.nc')
+    r = 3.6
+    assert_allclose(dataset.ems.bounds, (-r, -r, r, r))
+
+    # We also want to check that we didn't make the geometry to calculate this
+    assert_property_not_cached(dataset.ems, 'geometry')
 
 
 @pytest.mark.parametrize(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import itertools
 from functools import cached_property
-from typing import Dict, Hashable, List, Optional, Tuple
+from typing import Any, Dict, Hashable, List, Optional, Tuple
 
 import numpy as np
 import shapely
@@ -350,3 +350,19 @@ class RadialShocGrid(ShocGridGenerator):
 
     def make_y_grid(self, j: np.ndarray, i: np.ndarray) -> np.ndarray:
         return 0.1 * (5 + j) * np.sin(np.pi - i * np.pi / (self.i_size))  # type: ignore
+
+
+def assert_property_not_cached(
+    instance: Any,
+    prop_name: str,
+    /,
+) -> None:
+    __tracebackhide__ = True  # noqa
+    cls = type(instance)
+    prop = getattr(cls, prop_name)
+    assert isinstance(prop, cached_property), \
+        "{instance!r}.{prop_name} is not a cached_property"
+
+    cache = instance.__dict__
+    assert prop.attrname not in cache, \
+        f"{instance!r}.{prop_name} was cached!"


### PR DESCRIPTION
Convention.geometry is a single Polygon that represents the dataset geometry, while Convention.bounds is the minimum bounds of the dataset. Both have default implementations, but specific conventions can override this implementation if there is a more efficient way of computing it.