### PR TITLE
Update minimum versions, add tests against latest dependency versions

### DIFF
--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -40,6 +40,7 @@ runs:
     - name: Install base Conda environment
       uses: conda-incubator/setup-miniconda@v2
       with:
+        mamba-version: "*"
         environment-file: continuous-integration/environment.yaml
         python-version: ${{ inputs.python-version }}
         channels: conda-forge

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -8,6 +8,11 @@ inputs:
     description: Name of the emsarray Python package artifact
     required: false
     default: "Python package"
+  install-latest:
+    description: Install latest dependency versions instead of locked versions
+    required: false
+    # All inputs are forced to strings
+    default: 'false'
 
 runs:
   using: composite
@@ -21,7 +26,6 @@ runs:
           continuous-integration/requirements.txt
           continuous-integration/environment.yaml
           setup.cfg
-        python-version: ${{ inputs.python-version }}
 
     - name: Fetch built emsarray package
       uses: actions/download-artifact@v3
@@ -30,7 +34,7 @@ runs:
         path: "dist/"
 
     - name: Cache conda packages
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/conda_pkgs_dir
         key:
@@ -48,10 +52,18 @@ runs:
       run: |
         conda install -c conda-forge wheel
 
-
-    - name: Install Python packages
+    - name: Install locked Python packages
+      if: ${{ inputs.install-latest == 'false' }}
       shell: bash -l {0}
       run: |
         pip install \
           -r continuous-integration/requirements.txt \
           dist/emsarray-*.whl
+
+    - name: Install latest Python packages
+      if: ${{ inputs.install-latest != 'false'}}
+      shell: bash -l {0}
+      run: |
+        wheels=( dist/emsarray-*.whl )
+        echo "${wheels[@]}"
+        pip install "${wheels[0]}[testing]"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,21 @@ jobs:
         run: unzip -l dist/*.whl | grep -q py.typed
 
   test:
+    name: python ${{ matrix.python-version }}, ${{ matrix.experimental && 'latest' || 'pinned' }} dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: ["build"]
 
+    # Allow failures for the latest versions
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
+        experimental: [false]
+        include:
+          - python-version: "3.11"
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3
@@ -46,6 +53,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           package-artifact-name: ${{ needs.build.outputs.artifact-name }}
+          install-latest: ${{ matrix.experimental }}
 
       - name: Run tests
         shell: bash -l {0}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -14,53 +14,66 @@ babel==2.12.1
     #   sphinx
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
+bokeh==3.2.2
+    # via dask
 bottleneck==1.3.7
     # via emsarray (setup.cfg)
-cachetools==5.3.0
+cachetools==5.3.1
     # via tox
-cartopy==0.21.1
+cartopy==0.22.0
     # via emsarray (setup.cfg)
-certifi==2023.5.7
+certifi==2023.7.22
     # via
+    #   netcdf4
     #   pyproj
     #   requests
 cftime==1.6.2
     # via netcdf4
-chardet==5.1.0
+chardet==5.2.0
     # via tox
-charset-normalizer==3.1.0
+charset-normalizer==3.2.0
     # via requests
-click==8.1.3
-    # via dask
+click==8.1.7
+    # via
+    #   dask
+    #   distributed
 cloudpickle==2.2.1
-    # via dask
+    # via
+    #   dask
+    #   distributed
 colorama==0.4.6
     # via tox
-contourpy==1.0.7
-    # via matplotlib
-coverage[toml]==7.2.5
+contourpy==1.1.0
+    # via
+    #   bokeh
+    #   matplotlib
+coverage[toml]==7.3.0
     # via pytest-cov
 cycler==0.11.0
     # via matplotlib
-dask[complete]==2023.4.1
-    # via xarray
-distlib==0.3.6
+dask[array,complete,dataframe,diagnostics,distributed]==2023.8.1
+    # via
+    #   distributed
+    #   xarray
+distlib==0.3.7
     # via virtualenv
-docutils==0.17.1
+distributed==2023.8.1
+    # via dask
+docutils==0.19
     # via
     #   pydata-sphinx-theme
     #   sphinx
-exceptiongroup==1.1.1
+exceptiongroup==1.1.3
     # via pytest
-filelock==3.12.0
+filelock==3.12.2
     # via
     #   tox
     #   virtualenv
-flake8==6.0.0
+flake8==6.1.0
     # via emsarray (setup.cfg)
-fonttools==4.39.4
+fonttools==4.42.1
     # via matplotlib
-fsspec==2023.5.0
+fsspec==2023.6.0
     # via dask
 geojson==3.0.1
     # via emsarray (setup.cfg)
@@ -68,7 +81,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.6.0
+importlib-metadata==6.8.0
     # via
     #   dask
     #   emsarray (setup.cfg)
@@ -77,46 +90,60 @@ iniconfig==2.0.0
 isort==5.12.0
     # via emsarray (setup.cfg)
 jinja2==3.1.2
-    # via sphinx
+    # via
+    #   bokeh
+    #   dask
+    #   distributed
+    #   sphinx
 kiwisolver==1.4.4
     # via matplotlib
 livereload==2.6.3
     # via emsarray (setup.cfg)
 locket==1.0.0
-    # via partd
+    # via
+    #   distributed
+    #   partd
 lz4==4.3.2
     # via dask
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
-matplotlib==3.7.1
+matplotlib==3.7.2
     # via
     #   cartopy
     #   emsarray (setup.cfg)
 mccabe==0.7.0
     # via flake8
-mypy==1.3.0
+msgpack==1.0.5
+    # via distributed
+mypy==1.5.1
     # via emsarray (setup.cfg)
 mypy-extensions==1.0.0
     # via mypy
-netcdf4==1.6.3
+netcdf4==1.6.4
     # via emsarray (setup.cfg)
-numpy==1.24.3
+numpy==1.25.2
     # via
+    #   bokeh
     #   bottleneck
     #   cartopy
     #   cftime
     #   contourpy
+    #   dask
     #   emsarray (setup.cfg)
     #   matplotlib
     #   netcdf4
     #   pandas
+    #   pandas-stubs
     #   pyarrow
     #   pykdtree
     #   shapely
     #   xarray
 packaging==23.1
     # via
+    #   bokeh
+    #   cartopy
     #   dask
+    #   distributed
     #   emsarray (setup.cfg)
     #   matplotlib
     #   pooch
@@ -126,34 +153,41 @@ packaging==23.1
     #   sphinx
     #   tox
     #   xarray
-pandas==2.0.1
-    # via xarray
-pandas-stubs==2.0.1.230501
+pandas==2.0.3
+    # via
+    #   bokeh
+    #   dask
+    #   xarray
+pandas-stubs==2.0.3.230814
     # via emsarray (setup.cfg)
 partd==1.4.0
     # via dask
-pillow==9.5.0
-    # via matplotlib
-platformdirs==3.5.0
+pillow==10.0.0
+    # via
+    #   bokeh
+    #   matplotlib
+platformdirs==3.10.0
     # via
     #   pooch
     #   tox
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.2.0
     # via
     #   pytest
     #   tox
 pooch==1.7.0
     # via emsarray (setup.cfg)
-pyarrow==12.0.0
+psutil==5.9.5
+    # via distributed
+pyarrow==13.0.0
     # via dask
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pydata-sphinx-theme==0.13.3
     # via sphinx-book-theme
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pygments==2.15.1
+pygments==2.16.1
     # via
     #   accessible-pygments
     #   pydata-sphinx-theme
@@ -162,19 +196,19 @@ pykdtree==1.3.7.post0
     # via emsarray (setup.cfg)
 pyparsing==3.0.9
     # via matplotlib
-pyproj==3.5.0
+pyproj==3.6.0
     # via cartopy
-pyproject-api==1.5.1
+pyproject-api==1.5.4
     # via tox
 pyshp==2.3.1
     # via
     #   cartopy
     #   emsarray (setup.cfg)
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   emsarray (setup.cfg)
     #   pytest-cov
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via emsarray (setup.cfg)
 python-dateutil==2.8.2
     # via
@@ -182,9 +216,12 @@ python-dateutil==2.8.2
     #   pandas
 pytz==2023.3
     # via pandas
-pyyaml==6.0
-    # via dask
-requests==2.30.0
+pyyaml==6.0.1
+    # via
+    #   bokeh
+    #   dask
+    #   distributed
+requests==2.31.0
     # via
     #   pooch
     #   sphinx
@@ -198,27 +235,36 @@ six==1.16.0
     #   python-dateutil
 snowballstemmer==2.2.0
     # via sphinx
+sortedcontainers==2.4.0
+    # via distributed
 soupsieve==2.4.1
     # via beautifulsoup4
-sphinx==4.3.2
+sphinx==6.2.1
     # via
     #   emsarray (setup.cfg)
     #   pydata-sphinx-theme
     #   sphinx-book-theme
+    #   sphinxcontrib-applehelp
+    #   sphinxcontrib-devhelp
+    #   sphinxcontrib-htmlhelp
+    #   sphinxcontrib-qthelp
+    #   sphinxcontrib-serializinghtml
 sphinx-book-theme==1.0.1
     # via emsarray (setup.cfg)
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==1.0.7
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==1.0.5
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.4
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==1.0.6
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==1.1.9
     # via sphinx
+tblib==2.0.0
+    # via distributed
 tomli==2.0.1
     # via
     #   coverage
@@ -229,29 +275,36 @@ tomli==2.0.1
 toolz==0.12.0
     # via
     #   dask
+    #   distributed
     #   partd
-tornado==6.3.1
-    # via livereload
-tox==4.5.1
+tornado==6.3.3
+    # via
+    #   bokeh
+    #   distributed
+    #   livereload
+tox==4.10.0
     # via emsarray (setup.cfg)
-types-pytz==2023.3.0.0
+types-pytz==2023.3.0.1
     # via
     #   emsarray (setup.cfg)
     #   pandas-stubs
-typing-extensions==4.5.0
+typing-extensions==4.7.1
     # via
     #   mypy
     #   pydata-sphinx-theme
 tzdata==2023.3
     # via pandas
-urllib3==2.0.2
-    # via requests
-virtualenv==20.23.0
+urllib3==2.0.4
+    # via
+    #   distributed
+    #   requests
+virtualenv==20.24.3
     # via tox
-xarray[parallel]==2023.1.0
+xarray[parallel]==2023.8.0
     # via emsarray (setup.cfg)
-zipp==3.15.0
+xyzservices==2023.7.0
+    # via bokeh
+zict==3.0.0
+    # via distributed
+zipp==3.16.2
     # via importlib-metadata
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -19,3 +19,6 @@ Next release (in development)
   (:pr:`91`).
 * Remove shorthand imports such as ``import xarray as xr``
   (:pr:`95`).
+* Drop Python 3.8 support.
+  Bump minimum dependency versions to those released in the past 18 months
+  (:pr:`96`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,11 @@ install_requires =
 	geojson >=2.5.0
 	importlib_metadata >=4.0.0
 	netcdf4 >=1.5.3
-	numpy >=1.18.0
+	numpy >=1.22.0
 	packaging >=21.3
 	shapely >=2.0.0
 	pyshp >=2.3.0
-	xarray[parallel] >=0.18.2
+	xarray[parallel] >=0.21.0
 
 [options.packages.find]
 where = src
@@ -42,8 +42,8 @@ emsarray = py.typed
 [options.extras_require]
 plot =
 	cartopy >=0.21.1
-	matplotlib >=3.4.3
-	pykdtree >=1.2.2
+	matplotlib >=3.5.2
+	pykdtree >=1.3.5
 
 tutorial =
 	pooch >=1.3.0
@@ -53,7 +53,7 @@ complete =
 	%(tutorial)s
 
 docs =
-	sphinx ~=4.3.1
+	sphinx ~=6.2.1
 	sphinx_book_theme ~=1.0.1
 	livereload~=2.6.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ long_description_content_type = text/markdown
 author = "Coastal Environmental Modelling team, Oceans and Atmosphere, CSIRO"
 author_email = "coasts@csiro.au"
 license = "BSD-3-Clause"
+python_requires = ">=3.9"
 
 project_urls =
 	Documentation = https://emsarray.readthedocs.io/

--- a/tests/masking/test_utils.py
+++ b/tests/masking/test_utils.py
@@ -44,7 +44,7 @@ def test_find_fill_value_masked_float(datasets):
         assert_dtype_equal(
             data_array.values,
             numpy.array([[1.0, 2.0], [numpy.nan, 4.0]], dtype=numpy.float64))
-        assert masking.find_fill_value(data_array) is numpy.nan
+        assert numpy.isnan(masking.find_fill_value(data_array))
 
     # When opened with mask_and_scale=False, xarray does nothing with masks.
     # The raw _FillValue should be returned.
@@ -68,7 +68,7 @@ def test_find_fill_value_masked_and_scaled_float(datasets):
         assert_dtype_equal(
             data_array.values,
             numpy.array([[1.0, 2.0], [numpy.nan, 4.0]], dtype=numpy.float32))
-        assert masking.find_fill_value(data_array) is numpy.nan
+        assert numpy.isnan(masking.find_fill_value(data_array))
 
     # When opened with mask_and_scale=False, xarray does nothing with masks.
     # The raw _FillValue should be returned.
@@ -92,7 +92,7 @@ def test_find_fill_value_masked_and_scaled_int(datasets):
         assert_dtype_equal(
             data_array.values,
             numpy.array([[1.0, 2.0], [numpy.nan, 4.0]], dtype=numpy.float32))
-        assert masking.find_fill_value(data_array) is numpy.nan
+        assert numpy.isnan(masking.find_fill_value(data_array))
 
     # When opened with mask_and_scale=False, xarray does nothing with masks.
     # The raw _FillValue should be returned.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
 isolated_build = true
+package = wheel
+wheel_build_env = .pkg
 envlist =
-	py{39,310,311}-pytest
+	py{39,310,311}-pytest-locked
+	py311-pytest-latest
 	lint,docs
 skip_missing_interpreters = true
 requires =
@@ -25,7 +28,11 @@ conda_deps =
 # Install the python dependencies through pip
 deps = -rcontinuous-integration/requirements.txt
 
-[testenv:py{39,310,311}-pytest]
+[testenv:py{39,310,311}-pytest-{locked,latest}]
+deps =
+	locked: -rcontinuous-integration/requirements.txt
+extras =
+	latest: testing
 commands =
 	pytest \
 		--junitxml=junit-{envname}.xml \

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 isolated_build = true
 envlist =
-	py{38,39,310,311}-pytest
+	py{39,310,311}-pytest
 	lint,docs
 skip_missing_interpreters = true
 requires =
@@ -25,7 +25,7 @@ conda_deps =
 # Install the python dependencies through pip
 deps = -rcontinuous-integration/requirements.txt
 
-[testenv:py{38,39,310,311}-pytest]
+[testenv:py{39,310,311}-pytest]
 commands =
 	pytest \
 		--junitxml=junit-{envname}.xml \


### PR DESCRIPTION
The latest version tests are allowed to fail in CI. They act as a warning of future issues once we bump supported versions.

This also drops support for Python 3.8, following the lead of numpy and other prominent packages.