### PR TITLE
Dimension convention

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -2,4 +2,11 @@
 Next release (in development)
 =============================
 
-* ...
+* Use 'ravel' and 'wind' as antonyms instead of 'ravel' and 'unravel'.
+  English is weird. 'Ravel' and 'unravel' mean the same thing!.
+  (:pr:`100`)
+* Added new :class:`emsarray.conventions.DimensionConvention` subclass.
+  For conventions with multiple grids defined on unique subsets of dimensions
+  this base class will provide a number of default method implementations.
+  All existing conventions have been updated to build off this base class.
+  (:pr:`100`)

--- a/src/emsarray/conventions/__init__.py
+++ b/src/emsarray/conventions/__init__.py
@@ -13,7 +13,10 @@ In other cases, you might want to override some default parameters.
 Convention instances can be instantiated directly in this case.
 Refer to each Convention implementation for details.
 """
-from ._base import Convention, GridKind, Index, SpatialIndexItem, Specificity
+from ._base import (
+    Convention, DimensionConvention, GridKind, Index, SpatialIndexItem,
+    Specificity
+)
 from ._registry import get_dataset_convention, register_convention
 from ._utils import open_dataset
 from .arakawa_c import ArakawaC
@@ -22,7 +25,8 @@ from .shoc import ShocSimple, ShocStandard
 from .ugrid import UGrid
 
 __all__ = [
-    "Convention", "GridKind", "Index", "SpatialIndexItem", "Specificity",
+    "Convention", "DimensionConvention", "GridKind", "Index",
+    "SpatialIndexItem", "Specificity",
     "get_dataset_convention", "register_convention",
     "open_dataset",
     "ArakawaC",

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -530,6 +530,7 @@ class Convention(abc.ABC, Generic[GridKind, Index]):
     def wind_index(
         self,
         linear_index: int,
+        *,
         grid_kind: Optional[GridKind] = None,
     ) -> Index:
         """Convert a linear index to a conventnion native index.
@@ -1585,6 +1586,8 @@ class DimensionConvention(Convention[GridKind, Index]):
 
     - :attr:`.grid_size`
     - :meth:`.get_grid_kind`
+    - :meth:`.ravel_index`
+    - :meth:`.wind_index`
     """
 
     @property
@@ -1679,3 +1682,20 @@ class DimensionConvention(Convention[GridKind, Index]):
         unpack_index
         """
         pass
+
+    def ravel_index(self, index: Index) -> int:
+        grid_kind, indices = self.unpack_index(index)
+        shape = self.grid_shape[grid_kind]
+        return int(numpy.ravel_multi_index(indices, shape))
+
+    def wind_index(
+        self,
+        linear_index: int,
+        *,
+        grid_kind: Optional[GridKind] = None,
+    ) -> Index:
+        if grid_kind is None:
+            grid_kind = self.default_grid_kind
+        shape = self.grid_shape[grid_kind]
+        indices = tuple(map(int, numpy.unravel_index(linear_index, shape)))
+        return self.pack_index(grid_kind, indices)

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -1589,6 +1589,7 @@ class DimensionConvention(Convention[GridKind, Index]):
     - :meth:`.ravel_index`
     - :meth:`.wind_index`
     - :meth:`.ravel`
+    - :meth:`.selector_for_index`
     """
 
     @property
@@ -1706,3 +1707,8 @@ class DimensionConvention(Convention[GridKind, Index]):
         dimensions = self.grid_dimensions[kind]
         return utils.ravel_dimensions(
             data_array, list(dimensions))
+
+    def selector_for_index(self, index: Index) -> Dict[Hashable, int]:
+        grid_kind, indices = self.unpack_index(index)
+        dimensions = self.grid_dimensions[grid_kind]
+        return dict(zip(dimensions, indices))

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -1588,6 +1588,7 @@ class DimensionConvention(Convention[GridKind, Index]):
     - :meth:`.get_grid_kind`
     - :meth:`.ravel_index`
     - :meth:`.wind_index`
+    - :meth:`.ravel`
     """
 
     @property
@@ -1699,3 +1700,9 @@ class DimensionConvention(Convention[GridKind, Index]):
         shape = self.grid_shape[grid_kind]
         indices = tuple(map(int, numpy.unravel_index(linear_index, shape)))
         return self.pack_index(grid_kind, indices)
+
+    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
+        kind = self.get_grid_kind(data_array)
+        dimensions = self.grid_dimensions[kind]
+        return utils.ravel_dimensions(
+            data_array, list(dimensions))

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -299,12 +299,6 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
             self.back.latitude.name,
         ]
 
-    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
-        kind = self.get_grid_kind(data_array)
-        topology = self._topology_for_grid_kind[kind]
-        dimensions = [topology.j_dimension, topology.i_dimension]
-        return utils.linearise_dimensions(data_array, list(dimensions))
-
     def make_clip_mask(
         self,
         clip_geometry: BaseGeometry,

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -258,7 +258,7 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
     def pack_index(self, grid_kind: ArakawaCGridKind, indices: Sequence[int]) -> ArakawaCIndex:
         return cast(ArakawaCIndex, (grid_kind, *indices))
 
-    def unravel_index(
+    def wind_index(
         self,
         index: int,
         grid_kind: Optional[ArakawaCGridKind] = None,
@@ -266,7 +266,7 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
         if grid_kind is None:
             grid_kind = ArakawaCGridKind.face
         topology = self._topology_for_grid_kind[grid_kind]
-        j, i = map(int, numpy.unravel_index(index, topology.shape))
+        j, i = map(int, numpy.wind_index(index, topology.shape))
         return (grid_kind, j, i)
 
     def ravel_index(self, indices: ArakawaCIndex) -> int:
@@ -293,8 +293,8 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
     @cached_property
     def face_centres(self) -> numpy.ndarray:
         centres = numpy.column_stack((
-            self.make_linear(self.face.longitude).values,
-            self.make_linear(self.face.latitude).values,
+            self.ravel(self.face.longitude).values,
+            self.ravel(self.face.latitude).values,
         ))
         return cast(numpy.ndarray, centres)
 
@@ -315,7 +315,7 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
             self.back.latitude.name,
         ]
 
-    def make_linear(self, data_array: xarray.DataArray) -> xarray.DataArray:
+    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
         kind = self.get_grid_kind(data_array)
         topology = self._topology_for_grid_kind[kind]
         dimensions = [topology.j_dimension, topology.i_dimension]

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -282,11 +282,6 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
         ))
         return cast(numpy.ndarray, centres)
 
-    def selector_for_index(self, index: ArakawaCIndex) -> Dict[Hashable, int]:
-        kind, j, i = index
-        topology = self._topology_for_grid_kind[kind]
-        return {topology.j_dimension: j, topology.i_dimension: i}
-
     def get_all_geometry_names(self) -> List[Hashable]:
         return [
             self.face.longitude.name,

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -258,22 +258,6 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
     def pack_index(self, grid_kind: ArakawaCGridKind, indices: Sequence[int]) -> ArakawaCIndex:
         return cast(ArakawaCIndex, (grid_kind, *indices))
 
-    def wind_index(
-        self,
-        index: int,
-        grid_kind: Optional[ArakawaCGridKind] = None,
-    ) -> ArakawaCIndex:
-        if grid_kind is None:
-            grid_kind = ArakawaCGridKind.face
-        topology = self._topology_for_grid_kind[grid_kind]
-        j, i = map(int, numpy.wind_index(index, topology.shape))
-        return (grid_kind, j, i)
-
-    def ravel_index(self, indices: ArakawaCIndex) -> int:
-        grid_kind, j, i = indices
-        topology = self._topology_for_grid_kind[grid_kind]
-        return int(numpy.ravel_multi_index((j, i), topology.shape))
-
     @cached_property
     @utils.timed_func
     def polygons(self) -> numpy.ndarray:

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -266,17 +266,6 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
     def pack_index(self, grid_kind: CFGridKind, indices: Sequence[int]) -> CFGridIndex:
         return cast(CFGridIndex, indices)
 
-    def wind_index(
-        self,
-        index: int,
-        grid_kind: Optional[CFGridKind] = None,
-    ) -> CFGridIndex:
-        y, x = map(int, numpy.unravel_index(index, self.topology.shape))
-        return (y, x)
-
-    def ravel_index(self, indices: CFGridIndex) -> int:
-        return int(numpy.ravel_multi_index(indices, self.topology.shape))
-
     def selector_for_index(self, index: CFGridIndex) -> Dict[Hashable, int]:
         y, x = index
         return {self.topology.y_dimension: y, self.topology.x_dimension: x}

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -266,10 +266,6 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
     def pack_index(self, grid_kind: CFGridKind, indices: Sequence[int]) -> CFGridIndex:
         return cast(CFGridIndex, indices)
 
-    def selector_for_index(self, index: CFGridIndex) -> Dict[Hashable, int]:
-        y, x = index
-        return {self.topology.y_dimension: y, self.topology.x_dimension: x}
-
     def get_all_geometry_names(self) -> List[Hashable]:
         # Grid datasets contain latitude and longitude variables
         # plus optional bounds variables.

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -293,10 +293,6 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
         dataset.attrs.pop('Conventions', None)
         return dataset
 
-    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
-        surface_dims = [self.topology.y_dimension, self.topology.x_dimension]
-        return utils.linearise_dimensions(data_array, surface_dims)
-
     def make_clip_mask(
         self,
         clip_geometry: BaseGeometry,

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -266,7 +266,7 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
     def pack_index(self, grid_kind: CFGridKind, indices: Sequence[int]) -> CFGridIndex:
         return cast(CFGridIndex, indices)
 
-    def unravel_index(
+    def wind_index(
         self,
         index: int,
         grid_kind: Optional[CFGridKind] = None,
@@ -304,7 +304,7 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
         dataset.attrs.pop('Conventions', None)
         return dataset
 
-    def make_linear(self, data_array: xarray.DataArray) -> xarray.DataArray:
+    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
         surface_dims = [self.topology.y_dimension, self.topology.x_dimension]
         return utils.linearise_dimensions(data_array, surface_dims)
 
@@ -605,7 +605,7 @@ class CFGrid2D(CFGrid[CFGrid2DTopology]):
     @cached_property
     def face_centres(self) -> numpy.ndarray:
         centres = numpy.column_stack((
-            self.make_linear(self.topology.longitude).values,
-            self.make_linear(self.topology.latitude).values,
+            self.ravel(self.topology.longitude).values,
+            self.ravel(self.topology.latitude).values,
         ))
         return cast(numpy.ndarray, centres)

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1129,11 +1129,6 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
             return {self.topology.node_dimension: i}
         raise ValueError("Invalid index")  # pragma: no-cover
 
-    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
-        grid_kind = self.get_grid_kind(data_array)
-        grid_dimension = self.topology.dimension_for_grid_kind[grid_kind]
-        return utils.linearise_dimensions(data_array, [grid_dimension])
-
     def make_clip_mask(
         self,
         clip_geometry: BaseGeometry,

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1066,18 +1066,6 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
     def pack_index(self, grid_kind: UGridKind, indices: Sequence[int]) -> UGridIndex:
         return (grid_kind, indices[0])
 
-    def ravel_index(self, index: UGridIndex) -> int:
-        return index[1]
-
-    def wind_index(
-        self,
-        index: int,
-        grid_kind: Optional[UGridKind] = None,
-    ) -> UGridIndex:
-        if grid_kind is None:
-            grid_kind = UGridKind.face
-        return (grid_kind, index)
-
     @cached_property
     def grid_kinds(self) -> FrozenSet[UGridKind]:
         items = [UGridKind.face, UGridKind.node]

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1116,19 +1116,6 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
         max_y = numpy.nanmax(topology.node_y)
         return (min_x, min_y, max_x, max_y)
 
-    def selector_for_index(self, index: UGridIndex) -> Dict[Hashable, int]:
-        kind, i = index
-        if kind is UGridKind.face:
-            return {self.topology.face_dimension: i}
-        if kind is UGridKind.edge:
-            if self.topology.has_edge_dimension:
-                return {self.topology.edge_dimension: i}
-            else:
-                raise ValueError("Grid has no edge dimension")
-        if kind is UGridKind.node:
-            return {self.topology.node_dimension: i}
-        raise ValueError("Invalid index")  # pragma: no-cover
-
     def make_clip_mask(
         self,
         clip_geometry: BaseGeometry,

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1069,7 +1069,7 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
     def ravel_index(self, index: UGridIndex) -> int:
         return index[1]
 
-    def unravel_index(
+    def wind_index(
         self,
         index: int,
         grid_kind: Optional[UGridKind] = None,
@@ -1141,7 +1141,7 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
             return {self.topology.node_dimension: i}
         raise ValueError("Invalid index")  # pragma: no-cover
 
-    def make_linear(self, data_array: xarray.DataArray) -> xarray.DataArray:
+    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
         grid_kind = self.get_grid_kind(data_array)
         grid_dimension = self.topology.dimension_for_grid_kind[grid_kind]
         return utils.linearise_dimensions(data_array, [grid_dimension])

--- a/src/emsarray/operations/geometry.py
+++ b/src/emsarray/operations/geometry.py
@@ -75,7 +75,7 @@ def to_geojson(
     return geojson.FeatureCollection(_dumpable_iterator(
         geojson.Feature(geometry=polygon, properties={
             'linear_index': i,
-            'index': dataset.ems.unravel_index(i),
+            'index': dataset.ems.wind_index(i),
         })
         for i, polygon in enumerate(dataset.ems.polygons)
         if polygon is not None
@@ -167,7 +167,7 @@ def write_shapefile(
             writer.record(
                 name=f'polygon{i}',
                 linear_index=i,
-                index=json.dumps(dataset.ems.unravel_index(i)),
+                index=json.dumps(dataset.ems.wind_index(i)),
             )
             writer.shape(polygon.__geo_interface__)
 

--- a/src/emsarray/plot.py
+++ b/src/emsarray/plot.py
@@ -272,7 +272,7 @@ def animate_on_figure(
     collection = None
     if scalar is not None:
         # Plot a scalar variable on the polygons using a colour map
-        scalar_values = convention.make_linear(scalar).values[:, convention.mask]
+        scalar_values = convention.ravel(scalar).values[:, convention.mask]
         collection = convention.make_poly_collection(
             cmap='jet', edgecolor='face',
             clim=(numpy.nanmin(scalar_values), numpy.nanmax(scalar_values)))
@@ -285,7 +285,7 @@ def animate_on_figure(
     if vector is not None:
         # Plot a vector variable using a quiver
         vector_u_values, vector_v_values = (
-            convention.make_linear(vec).values
+            convention.ravel(vec).values
             for vec in vector)
         # Quivers must start with some data.
         # Vector arrows are scaled using this initial data.

--- a/src/emsarray/utils.py
+++ b/src/emsarray/utils.py
@@ -561,7 +561,7 @@ def move_dimensions_to_end(
         return data_array.transpose(*new_order)
 
 
-def linearise_dimensions(
+def ravel_dimensions(
     data_array: xarray.DataArray,
     dimensions: List[Hashable],
     linear_dimension: Optional[Hashable] = None,
@@ -600,7 +600,7 @@ def linearise_dimensions(
         ...     data=numpy.random.random((3, 5, 7)),
         ...     dims=['x', 'y', 'z'],
         ... )
-        >>> flattened = linearise_dimensions(data_array, ['y', 'x'])
+        >>> flattened = ravel_dimensions(data_array, ['y', 'x'])
         >>> flattened.dims
         ('z', 'index')
         >>> flattened.shape

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -49,11 +49,14 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
         y, x = map(int, self.dataset['botz'].shape)
         return (y, x)
 
-    def get_grid_kind_and_size(self, data_array: xarray.DataArray) -> Tuple[SimpleGridKind, int]:
-        expected = {'y', 'x'}
-        if expected.issubset(data_array.dims):
-            return (SimpleGridKind.face, int(numpy.prod(self.shape)))
-        raise ValueError("Invalid dimensions")
+    @cached_property
+    def grid_size(self) -> Dict[SimpleGridKind, int]:
+        return {SimpleGridKind.face: int(numpy.prod(self.shape))}
+
+    def get_grid_kind(self, data_array: xarray.DataArray) -> SimpleGridKind:
+        if set(data_array.dims) >= {'x', 'y'}:
+            return SimpleGridKind.face
+        raise ValueError("Unknown grid type")
 
     def get_all_geometry_names(self) -> List[Hashable]:
         return ['x', 'y']

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -61,7 +61,7 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
     def get_all_geometry_names(self) -> List[Hashable]:
         return ['x', 'y']
 
-    def unravel_index(
+    def wind_index(
         self,
         index: int,
         grid_kind: Optional[SimpleGridKind] = None,
@@ -75,8 +75,8 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
     def selector_for_index(self, index: SimpleGridIndex) -> Dict[Hashable, int]:
         return {'x': index.x, 'y': index.y}
 
-    def make_linear(self, data_array: xarray.DataArray) -> xarray.DataArray:
-        return utils.linearise_dimensions(data_array, ['y', 'x'])
+    def ravel(self, data_array: xarray.DataArray) -> xarray.DataArray:
+        return utils.ravel_dimensions(data_array, ['y', 'x'])
 
     def drop_geometry(self) -> xarray.Dataset:
         return self.dataset
@@ -504,7 +504,7 @@ def test_make_poly_collection_data_array():
     patches = convention.make_poly_collection(data_array='botz')
     assert len(patches.get_paths()) == len(convention.polygons[convention.mask])
 
-    values = convention.make_linear(dataset.data_vars['botz'])[convention.mask]
+    values = convention.ravel(dataset.data_vars['botz'])[convention.mask]
     numpy.testing.assert_equal(patches.get_array(), values)
     assert patches.get_clim() == (numpy.nanmin(values), numpy.nanmax(values))
 

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -64,6 +64,7 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
     def wind_index(
         self,
         index: int,
+        *,
         grid_kind: Optional[SimpleGridKind] = None,
     ) -> SimpleGridIndex:
         y, x = map(int, numpy.unravel_index(index, self.shape))

--- a/tests/conventions/test_cfgrid1d.py
+++ b/tests/conventions/test_cfgrid1d.py
@@ -321,7 +321,7 @@ def test_ravel():
     for index in range(3 * 5):
         y, x = divmod(index, 3)
         assert convention.ravel_index((y, x)) == index
-        assert convention.unravel_index(index) == (y, x)
+        assert convention.wind_index(index) == (y, x)
 
 
 def test_grid_kinds():
@@ -356,7 +356,7 @@ def test_drop_geometry(datasets: pathlib.Path):
 def test_values():
     dataset = make_dataset(width=3, height=5)
     eta = dataset.data_vars["eta"].isel(time=0)
-    values = dataset.ems.make_linear(eta)
+    values = dataset.ems.ravel(eta)
 
     # There should be one value per cell polygon
     assert len(values) == len(dataset.ems.polygons)

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -346,8 +346,8 @@ def test_ravel():
     for linear_index, (j, i) in enumerate(itertools.product(range(5), range(7))):
         index = (j, i)
         assert convention.ravel_index(index) == linear_index
-        assert convention.unravel_index(linear_index) == index
-        assert convention.unravel_index(linear_index, CFGridKind.face) == index
+        assert convention.wind_index(linear_index) == index
+        assert convention.wind_index(linear_index, CFGridKind.face) == index
 
 
 def test_grid_kinds():
@@ -383,7 +383,7 @@ def test_drop_geometry(datasets: pathlib.Path):
 def test_values():
     dataset = make_dataset(j_size=10, i_size=20, corner_size=5)
     eta = dataset.data_vars["eta"].isel(time=0)
-    values = dataset.ems.make_linear(eta)
+    values = dataset.ems.ravel(eta)
 
     # There should be one value per cell polygon
     assert len(values) == len(dataset.ems.polygons)

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -347,7 +347,7 @@ def test_ravel():
         index = (j, i)
         assert convention.ravel_index(index) == linear_index
         assert convention.wind_index(linear_index) == index
-        assert convention.wind_index(linear_index, CFGridKind.face) == index
+        assert convention.wind_index(linear_index, grid_kind=CFGridKind.face) == index
 
 
 def test_grid_kinds():

--- a/tests/conventions/test_shoc_standard.py
+++ b/tests/conventions/test_shoc_standard.py
@@ -266,15 +266,15 @@ def test_make_geojson_geometry():
     assert isinstance(out, str)
 
 
-def test_ravel():
+def test_ravel() -> None:
     dataset = make_dataset(j_size=5, i_size=7)
     convention: ShocStandard = dataset.ems
 
     for ravelled, (j, i) in enumerate(itertools.product(range(5), range(7))):
         index = (ArakawaCGridKind.face, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.unravel_index(ravelled) == index
-        assert convention.unravel_index(ravelled, ArakawaCGridKind.face) == index
+        assert convention.wind_index(ravelled) == index
+        assert convention.wind_index(ravelled, ArakawaCGridKind.face) == index
 
 
 def test_ravel_left():
@@ -284,7 +284,7 @@ def test_ravel_left():
     for ravelled, (j, i) in enumerate(itertools.product(range(5), range(8))):
         index = (ArakawaCGridKind.left, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.unravel_index(ravelled, ArakawaCGridKind.left) == index
+        assert convention.wind_index(ravelled, ArakawaCGridKind.left) == index
 
 
 def test_ravel_back():
@@ -294,7 +294,7 @@ def test_ravel_back():
     for ravelled, (j, i) in enumerate(itertools.product(range(6), range(7))):
         index = (ArakawaCGridKind.back, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.unravel_index(ravelled, ArakawaCGridKind.back) == index
+        assert convention.wind_index(ravelled, ArakawaCGridKind.back) == index
 
 
 def test_ravel_grid():
@@ -304,7 +304,7 @@ def test_ravel_grid():
     for ravelled, (j, i) in enumerate(itertools.product(range(6), range(8))):
         index = (ArakawaCGridKind.node, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.unravel_index(ravelled, ArakawaCGridKind.node) == index
+        assert convention.wind_index(ravelled, ArakawaCGridKind.node) == index
 
 
 def test_grid_kinds():
@@ -434,7 +434,7 @@ def test_drop_geometry(datasets: pathlib.Path):
 def test_values():
     dataset = make_dataset(j_size=10, i_size=20, corner_size=5)
     eta = dataset.data_vars["eta"].isel(record=0)
-    values = dataset.ems.make_linear(eta)
+    values = dataset.ems.ravel(eta)
 
     # There should be one value per cell polygon
     assert len(values) == len(dataset.ems.polygons)

--- a/tests/conventions/test_shoc_standard.py
+++ b/tests/conventions/test_shoc_standard.py
@@ -274,7 +274,7 @@ def test_ravel() -> None:
         index = (ArakawaCGridKind.face, j, i)
         assert convention.ravel_index(index) == ravelled
         assert convention.wind_index(ravelled) == index
-        assert convention.wind_index(ravelled, ArakawaCGridKind.face) == index
+        assert convention.wind_index(ravelled, grid_kind=ArakawaCGridKind.face) == index
 
 
 def test_ravel_left():
@@ -284,7 +284,7 @@ def test_ravel_left():
     for ravelled, (j, i) in enumerate(itertools.product(range(5), range(8))):
         index = (ArakawaCGridKind.left, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.wind_index(ravelled, ArakawaCGridKind.left) == index
+        assert convention.wind_index(ravelled, grid_kind=ArakawaCGridKind.left) == index
 
 
 def test_ravel_back():
@@ -294,7 +294,7 @@ def test_ravel_back():
     for ravelled, (j, i) in enumerate(itertools.product(range(6), range(7))):
         index = (ArakawaCGridKind.back, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.wind_index(ravelled, ArakawaCGridKind.back) == index
+        assert convention.wind_index(ravelled, grid_kind=ArakawaCGridKind.back) == index
 
 
 def test_ravel_grid():
@@ -304,7 +304,7 @@ def test_ravel_grid():
     for ravelled, (j, i) in enumerate(itertools.product(range(6), range(8))):
         index = (ArakawaCGridKind.node, j, i)
         assert convention.ravel_index(index) == ravelled
-        assert convention.wind_index(ravelled, ArakawaCGridKind.node) == index
+        assert convention.wind_index(ravelled, grid_kind=ArakawaCGridKind.node) == index
 
 
 def test_grid_kinds():

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -463,12 +463,12 @@ def test_ravel():
     for linear_index in range(dataset.ems.topology.edge_count):
         index = (UGridKind.edge, linear_index)
         assert convention.ravel_index(index) == linear_index
-        assert convention.wind_index(linear_index, UGridKind.edge) == index
+        assert convention.wind_index(linear_index, grid_kind=UGridKind.edge) == index
 
     for linear_index in range(dataset.ems.topology.node_count):
         index = (UGridKind.node, linear_index)
         assert convention.ravel_index(index) == linear_index
-        assert convention.wind_index(linear_index, UGridKind.node) == index
+        assert convention.wind_index(linear_index, grid_kind=UGridKind.node) == index
 
 
 def test_grid_kinds_with_edges():

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -458,17 +458,17 @@ def test_ravel():
     for linear_index in range(dataset.dims['nMesh2_face']):
         index = (UGridKind.face, linear_index)
         assert convention.ravel_index(index) == linear_index
-        assert convention.unravel_index(linear_index) == index
+        assert convention.wind_index(linear_index) == index
 
     for linear_index in range(dataset.ems.topology.edge_count):
         index = (UGridKind.edge, linear_index)
         assert convention.ravel_index(index) == linear_index
-        assert convention.unravel_index(linear_index, UGridKind.edge) == index
+        assert convention.wind_index(linear_index, UGridKind.edge) == index
 
     for linear_index in range(dataset.ems.topology.node_count):
         index = (UGridKind.node, linear_index)
         assert convention.ravel_index(index) == linear_index
-        assert convention.unravel_index(linear_index, UGridKind.node) == index
+        assert convention.wind_index(linear_index, UGridKind.node) == index
 
 
 def test_grid_kinds_with_edges():
@@ -585,7 +585,7 @@ def test_drop_geometry_full():
 def test_values():
     dataset = make_dataset(width=3)
     eta = dataset.data_vars["eta"].isel(record=0)
-    values = dataset.ems.make_linear(eta)
+    values = dataset.ems.ravel(eta)
 
     # There should be one value per face
     assert len(values) == dataset.ems.topology.face_count

--- a/tests/operations/test_geometry.py
+++ b/tests/operations/test_geometry.py
@@ -45,7 +45,7 @@ def test_write_geojson(datasets: pathlib.Path, tmp_path: pathlib.Path):
         actual_polygon = shapely.geometry.shape(row.feature['geometry'])
         assert_geometries_equal(row.polygon, actual_polygon, tolerance=1e-6)
         assert row.linear_index == row.feature['properties']['linear_index']
-        assert _json_roundtrip(dataset.ems.unravel_index(row.linear_index)) \
+        assert _json_roundtrip(dataset.ems.wind_index(row.linear_index)) \
             == row.feature['properties']['index']
 
     saved_geometry = shapely.from_geojson(out_path.read_bytes())
@@ -71,7 +71,7 @@ def test_write_shapefile(datasets: pathlib.Path, tmp_path: pathlib.Path):
         for row in polygons.itertuples():
             assert row.shape_record.record[1] == row.linear_index
             assert json.loads(row.shape_record.record[2]) \
-                == _json_roundtrip(dataset.ems.unravel_index(row.linear_index))
+                == _json_roundtrip(dataset.ems.wind_index(row.linear_index))
             actual_polygon = shapely.geometry.shape(row.shape_record.__geo_interface__['geometry']),
             assert_geometries_equal(actual_polygon, row.polygon)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -428,7 +428,7 @@ def test_linearize_dimensions_exact_dimensions():
         data=data_array.values.ravel(),
         dims=['index'],
     )
-    linearized = utils.linearise_dimensions(data_array, ['y', 'x'])
+    linearized = utils.ravel_dimensions(data_array, ['y', 'x'])
     xarray.testing.assert_equal(linearized, expected)
 
 
@@ -451,7 +451,7 @@ def test_linearize_dimensions_extra_dimensions():
             'z': data_array.coords['z'],
         },
     )
-    linearized = utils.linearise_dimensions(data_array, ['y', 'x'])
+    linearized = utils.ravel_dimensions(data_array, ['y', 'x'])
     xarray.testing.assert_equal(linearized, expected)
 
 
@@ -464,7 +464,7 @@ def test_linearize_dimensions_custom_name():
         data=numpy.reshape(numpy.transpose(data_array.values, (0, 3, 2, 1)), (2, 3, -1)),
         dims=['t', 'z', 'i'],
     )
-    linearized = utils.linearise_dimensions(data_array, ['y', 'x'], linear_dimension='i')
+    linearized = utils.ravel_dimensions(data_array, ['y', 'x'], linear_dimension='i')
     xarray.testing.assert_equal(linearized, expected)
 
 
@@ -477,5 +477,5 @@ def test_linearize_dimensions_auto_name_conflict():
         data=numpy.reshape(numpy.transpose(data_array.values, (0, 1, 3, 2)), (2, 7, -1)),
         dims=['index', 'index_0', 'index_1'],
     )
-    linearized = utils.linearise_dimensions(data_array, ['index_2', 'index_1'])
+    linearized = utils.ravel_dimensions(data_array, ['index_2', 'index_1'])
     xarray.testing.assert_equal(linearized, expected)


### PR DESCRIPTION
Most conventions define grids on non-overlapping sets of dimensions. For example, Arakawa C datasets have four different grids, where each grid uses two dimensions, but no two grids share any dimensions. An index is a combination of a grid kind and a set of indices that match the grid dimensions. All current conventions follow this pattern.

A new DimensionConvention subclass has been added that encapsulates this. By formalising this relationship default implementations for `.ravel_index`, `.wind_index`, `.ravel`, `.selector_for_index`, and `.get_grid_kind` can be provided

As part of this, the antonyms 'ravel' and 'wind' replaced 'ravel' and 'unravel'. Numpy uses 'ravel' and 'unravel' to mean the inverse operation, but in English 'ravel' and 'unravel' mean the same thing. 'Wind' was chosen instead, leaving 'ravel' to match `numpy.ravel`.