### PR TITLE
Add Convention.strtree, deprecate Convention.spatial_index

### DIFF
--- a/docs/concepts/indexing.rst
+++ b/docs/concepts/indexing.rst
@@ -54,10 +54,10 @@ This will return a tuple of ``(kind, size)``.
 ``kind`` is the native index kind (face, edge, node, etc),
 while ``size`` is the length of the linear index space for that grid.
 
-Looking up a location in the :attr:`Convention.spatial_index`
-will return a :class:`.SpatialIndexItem` instance.
-These values have a :attr:`~.SpatialIndexItem.linear_index` attribute
-and a :attr:`~.SpatialIndexItem.index` attribute.
+:attr:`.Convention.strtree`
+is a :class:`spatial index <shapely.strtree.STRtree>`
+of all cells in the dataset.
+Querying it will return the linear index for any matching cells.
 
 The cell polygons in :attr:`Convention.polygons <.Convention.polygons>`
 are in linear index order.

--- a/docs/developing/grass.py
+++ b/docs/developing/grass.py
@@ -68,18 +68,12 @@ class Grass(DimensionConvention[GrassGridKind, GrassIndex]):
         buffer: int = 0,
     ) -> xarray.Dataset:
         # Find all the fields that intersect the clip geometry
-        intersecting_fields = [
-            field
-            for field, polygon in self.spatial_index.query(clip_geometry)
-            if polygon.intersects(clip_geometry)
-        ]
-        # Get all the linear indexes of the intersecting blades
-        field_indexes = numpy.array([i.linear_index for i in intersecting_fields])
+        field_indexes = self.strtree.query(clip_geometry, predicate='intersects')
         # Find all the fences associated with each intesecting field
         fence_indexes = numpy.unique([
             self.ravel_index(fence_index)
-            for field in intersecting_fields
-            for fence_index in self.get_fences_around_field(field.index)
+            for field_index in field_indexes
+            for fence_index in self.get_fences_around_field(field_index)
         ])
 
         # Make an array of which fields to keep

--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -13,3 +13,8 @@ Next release (in development)
 * Remove workaround for `pydata/xarray#6049 <https://github.com/pydata/xarray/pull/6049>`_ (:pr:`101`).
 * Add :meth:`.Convention.wind()` method as the inverse to :meth:`.Convention.ravel()`
   (:pr:`102`).
+* Add :attr:`.Convention.strtree()` spatial index,
+  deprecate :attr:`.Convention.spatial_index()`.
+  The old attribute was a compatibility shim around Shapely 1.8.x STRtree implementation.
+  Now that the minimum version of Shapely is 2.0, the STRtree can be used directly.
+  (:pr:`103`).

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -307,10 +307,7 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
         logger.info("Finding intersecting cells for centre mask")
 
         # A cell is included if it intersects the clip polygon
-        intersecting_indices = [
-            item.linear_index
-            for polygon, item in self.spatial_index.query(clip_geometry)
-            if polygon.intersects(clip_geometry)]
+        intersecting_indices = self.strtree.query(clip_geometry, predicate='intersects')
         face_mask = numpy.full(self.face.shape, fill_value=False)
         face_mask.ravel()[intersecting_indices] = True
 

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -296,10 +296,7 @@ class CFGrid(Generic[Topology], DimensionConvention[CFGridKind, CFGridIndex]):
     ) -> xarray.Dataset:
         topology = self.topology
 
-        intersecting_indices = [
-            item.linear_index
-            for polygon, item in self.spatial_index.query(clip_geometry)
-            if polygon.intersects(clip_geometry)]
+        intersecting_indices = self.strtree.query(clip_geometry, predicate='intersects')
         mask = numpy.full(topology.shape, fill_value=False)
         mask.ravel()[intersecting_indices] = True
 

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1142,11 +1142,7 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
         """
         # Find all faces that intersect the clip geometry
         logger.info("Making clip mask")
-        face_indices = numpy.array([
-            item.linear_index
-            for polygon, item in self.spatial_index.query(clip_geometry)
-            if polygon.intersects(clip_geometry)
-        ])
+        face_indices = self.strtree.query(clip_geometry, predicate='intersects')
         logger.debug("Found %d intersecting faces, adding size %d buffer...", len(face_indices), buffer)
 
         # Include all the neighbours of the intersecting faces


### PR DESCRIPTION
Convention.spatial_index was a compatibility shim for shapely.strtree.STRtree, which changed considerably between versions 1.8 and 2.0. Version 2.0 is considerably improved, and can be used directly now. This PR deprecates the shim. Users should instead use the strtree directly.