### PR TITLE
Make `normalize_depth_variables()` parameters optional

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -20,4 +20,10 @@ Next release (in development)
   (:pr:`103`).
 * Add :meth:`emsarray.plot.add_landmarks()`
   and `landmarks` parameter to :meth:`Convention.plot` and related functions.
-  (:pr:`105`).
+  (:pr:`107`).
+* Make the `positive_down` and `deep_to_shallow` parameters optional
+  for :func:`~emsarray.operations.depth.normalize_depth_variables`.
+  If not supplied, that feature of the depth variable is not normalized.
+  This is a breaking change if you previously relied
+  on the default value of `True` for these parameters.
+  (:pr:`108`).

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -1716,7 +1716,10 @@ class Convention(abc.ABC, Generic[GridKind, Index]):
             non_spatial_variables=[self.get_time_name()])
 
     def normalize_depth_variables(
-        self, positive_down: bool = True, deep_to_shallow: bool = True,
+        self,
+        *,
+        positive_down: Optional[bool] = None,
+        deep_to_shallow: Optional[bool] = None,
     ) -> xarray.Dataset:
         """An alias for :func:`emsarray.operations.depth.normalize_depth_variables`"""
         return depth.normalize_depth_variables(

--- a/tests/operations/depth/test_normalize_depth_variables.py
+++ b/tests/operations/depth/test_normalize_depth_variables.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy
 import pytest
 import xarray
@@ -7,7 +9,7 @@ from emsarray.operations.depth import normalize_depth_variables
 
 
 @pytest.mark.parametrize(
-    "input_depths,input_positive,input_deep_to_shallow", [
+    ["input_depths", "input_positive", "input_deep_to_shallow"], [
         ([-1, +0, +1, +2, +3, +4], 'down', False),
         ([+4, +3, +2, +1, +0, -1], 'down', True),
         ([+1, +0, -1, -2, -3, -4], 'up', False),
@@ -16,31 +18,39 @@ from emsarray.operations.depth import normalize_depth_variables
 )
 @pytest.mark.parametrize("set_positive", [True, False])
 @pytest.mark.parametrize(
-    ["expected", "positive_down", "deep_to_shallow"], [
-        ([+4, +3, +2, +1, +0, -1], True, True),
-        ([-1, +0, +1, +2, +3, +4], True, False),
-        ([-4, -3, -2, -1, +0, +1], False, True),
-        ([+1, +0, -1, -2, -3, -4], False, False),
+    ["positive_down", "deep_to_shallow"], [
+        (None, None),
+        (None, True),
+        (None, False),
+        (True, None),
+        (True, True),
+        (True, False),
+        (False, None),
+        (False, True),
+        (False, False),
     ],
 )
 def test_normalize_depth_variable(
-    input_depths: numpy.ndarray, input_positive: str, input_deep_to_shallow: bool,
+    input_depths: list[int],
+    input_positive: str,
+    input_deep_to_shallow: bool,
     set_positive: bool,
-    expected: numpy.ndarray, positive_down: bool, deep_to_shallow: bool,
+    positive_down: Optional[bool],
+    deep_to_shallow: Optional[bool],
     recwarn,
 ):
-    input_depths = input_depths[:]
     # Some datasets have a coordinate with the same dimension name
+    positive_attr = {'positive': input_positive} if set_positive else {}
     depth_coord = xarray.DataArray(
         data=numpy.array(input_depths),
         dims=['depth_coord'],
-        attrs={'positive': input_positive if set_positive else None, 'foo': 'bar'},
+        attrs={**positive_attr, 'foo': 'bar'},
     )
     # Some dimensions have different coordinate and dimension names
     depth_name = xarray.DataArray(
         data=numpy.array(input_depths),
         dims=['depth_dimension'],
-        attrs={'positive': input_positive if set_positive else None, 'foo': 'bar'},
+        attrs={**positive_attr, 'foo': 'bar'},
     )
     values = numpy.arange(4 * 6 * 4).reshape(4, 6, 4)
     dataset = xarray.Dataset(
@@ -57,32 +67,45 @@ def test_normalize_depth_variable(
     )
 
     out = normalize_depth_variables(
-        dataset, ['depth_coord', 'depth_name'],
-        positive_down=positive_down, deep_to_shallow=deep_to_shallow,
+        dataset,
+        ['depth_coord', 'depth_name'],
+        positive_down=positive_down,
+        deep_to_shallow=deep_to_shallow,
     )
 
+    expected_attrs = {'foo': 'bar'}
+    if positive_down is None:
+        if set_positive:
+            expected_attrs['positive'] = input_positive
+    elif positive_down:
+        expected_attrs['positive'] = 'down'
+    else:
+        expected_attrs['positive'] = 'up'
+
     # Check that the values are reordered along the depth axis if required
-    expected_values = (
-        values[:, :, :] if (input_deep_to_shallow == deep_to_shallow)
-        else values[:, ::-1, :])
+    expected_values = values.copy()
+    if deep_to_shallow is not None and input_deep_to_shallow != deep_to_shallow:
+        expected_values = expected_values[:, ::-1, :]
     assert_equal(out['values_coord'].values, expected_values)
     assert_equal(out['values_dimension'].values, expected_values)
 
     # Check that attributes on the depth coordinate were not clobbered
-    assert out['depth_coord'].attrs == {
-        'positive': 'down' if positive_down else 'up',
-        'foo': 'bar',
-    }
-    assert out['depth_name'].attrs == {
-        'positive': 'down' if positive_down else 'up',
-        'foo': 'bar',
-    }
+    assert out['depth_coord'].attrs == expected_attrs
+    assert out['depth_name'].attrs == expected_attrs
 
     # Check the depth values are as expected
-    assert_equal(out['depth_coord'].values, expected)
+    # The depths should be similar to the inputs,
+    # possibly reversed and possibly negated depending on the input parameters.
+    expected_depths = numpy.array(input_depths)
+    if positive_down is not None and input_positive != expected_attrs['positive']:
+        expected_depths = -expected_depths
+    if deep_to_shallow is not None and input_deep_to_shallow != deep_to_shallow:
+        expected_depths = expected_depths[::-1]
+
+    assert_equal(out['depth_coord'].values, expected_depths)
     assert out['depth_coord'].dims == ('depth_coord',)
 
-    assert_equal(out['depth_name'].values, expected)
+    assert_equal(out['depth_name'].values, expected_depths)
     assert out['depth_name'].dims == ('depth_dimension',)
 
     assert out.dims['depth_coord'] == 6


### PR DESCRIPTION
If `positive_down` or `deep_to_shallow` are none, those parts of the depth variable are not normalized. Users can choose which aspects of the depth variable to normalize.