### PR TITLE
Make coasts and gridlines optional on plots

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -5,3 +5,11 @@ Next release (in development)
 * Fix transect plot title and units.
   All attributes were being dropped accidentally in `prepare_data_array_for_transect()`.
   (:pr:`114`).
+* Add `coast` and `gridlines` parameters to :func:`emsarray.plot.plot_on_figure()`,
+  allowing users to disable these components of a plot.
+  Currently gridlines can cause issues in interactive Jupyter notebooks
+  and some other environments.
+  There is no one solution to every situation.
+  Allowing users to disable gridlines is a temporary work around
+  while other solutions are being sought.
+  (:pr:`115`, :issue:`SciTools/cartopy#2245`, :issue:`SciTools/cartopy#2246`, :issue:`SciTools/cartopy#2247`).


### PR DESCRIPTION
There are currently a number of problems with gridlines on plots in Jupyter notebooks. There are different solutions that depend on whether you want an interactive plot, a static plot in a notebook, or are saving the plot to a file. Unfortunately there is no single solution that works in all cases currently. Until a proper solution is found, users can disable gridlines and then re-enable them in the way that works for their current environment.

https://github.com/SciTools/cartopy/issues/2245
https://github.com/SciTools/cartopy/issues/2246
https://github.com/SciTools/cartopy/issues/2247