### PR TITLE
Fix some warnings raised in the tests with xarray 2023.09.0

### DIFF
--- a/tests/conventions/test_cfgrid1d.py
+++ b/tests/conventions/test_cfgrid1d.py
@@ -86,6 +86,10 @@ def make_dataset(
     # EMS fails to parse. There is no way around this using xarray natively,
     # you have to adjust it with nctool after saving it.
     time.encoding["units"] = "days since 1990-01-01 00:00:00 +10"
+    # This can not be represented as an int, so explicitly set the dtype.
+    # xarray >=2023.09 warns when encoding variables without a dtype
+    # that can not be represented exactly.
+    time.encoding["dtype"] = "float32"
 
     botz = xarray.DataArray(
         data=numpy.random.random((height, width)) * 10 + 50,

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -94,6 +94,14 @@ def make_dataset(
             "coordinate_type": "time",
         },
     )
+    # Note: xarray will reformat this in to 1990-01-01T00:00:00+10:00, which
+    # EMS fails to parse. There is no way around this using xarray natively,
+    # you have to adjust it with nctool after saving it.
+    time.encoding["units"] = "days since 1990-01-01 00:00:00 +10"
+    # This can not be represented as an int, so explicitly set the dtype.
+    # xarray >=2023.09 warns when encoding variables without a dtype
+    # that can not be represented exactly.
+    time.encoding["dtype"] = "float32"
 
     botz = xarray.DataArray(
         data=numpy.random.random((j_size, i_size)) * 10 + 50,

--- a/tests/conventions/test_shoc_standard.py
+++ b/tests/conventions/test_shoc_standard.py
@@ -98,6 +98,10 @@ def make_dataset(
     # EMS fails to parse. There is no way around this using xarray natively,
     # you have to adjust it with nctool after saving it.
     t.encoding["units"] = "days since 1990-01-01 00:00:00 +10"
+    # This can not be represented as an int, so explicitly set the dtype.
+    # xarray >=2023.09 warns when encoding variables without a dtype
+    # that can not be represented exactly.
+    t.encoding["dtype"] = "float32"
 
     botz = xarray.DataArray(
         data=numpy.random.random((j_size, i_size)) * 10 + 50,

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -206,6 +206,10 @@ def make_dataset(
     # EMS fails to parse. There is no way around this using xarray natively,
     # you have to adjust it with nctool after saving it.
     t.encoding["units"] = "days since 1990-01-01 00:00:00 +10"
+    # This can not be represented as an int, so explicitly set the dtype.
+    # xarray >=2023.09 warns when encoding variables without a dtype
+    # that can not be represented exactly.
+    t.encoding["dtype"] = "float32"
 
     botz = xarray.DataArray(
         data=numpy.random.random(cell_size) * 10 + 50,

--- a/tests/masking/test_mask_dataset.py
+++ b/tests/masking/test_mask_dataset.py
@@ -136,6 +136,7 @@ def test_mask_dataset(tmp_path: pathlib.Path):
         },
     )
     t.encoding["units"] = "days since 1990-01-01 00:00:00 +10"
+    t.encoding["dtype"] = numpy.dtype("float32")
 
     botz_missing_value = numpy.float32(-99.)
     botz = xarray.DataArray(


### PR DESCRIPTION
xarray now explicitly complains if you're doing Bad Things, instead of silently trying to work with it. Explicit warnings are good! But now I have to not do those Bad Things.

This has the upside of removing one of the warnings the tests silenced, which can only be a good thing.