### PR TITLE
Drop dependency on importlib_metadata

### DIFF
--- a/continuous-integration/requirements.txt
+++ b/continuous-integration/requirements.txt
@@ -52,7 +52,9 @@ contourpy==1.1.0
     #   bokeh
     #   matplotlib
 coverage[toml]==7.3.0
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 cycler==0.11.0
     # via matplotlib
 dask[array,complete,dataframe,diagnostics,distributed]==2023.8.1
@@ -86,9 +88,7 @@ idna==3.4
 imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.8.0
-    # via
-    #   dask
-    #   emsarray (setup.cfg)
+    # via dask
 iniconfig==2.0.0
     # via pytest
 isort==5.12.0
@@ -307,7 +307,9 @@ urllib3==2.0.4
 virtualenv==20.24.3
     # via tox
 xarray[parallel]==2023.8.0
-    # via emsarray (setup.cfg)
+    # via
+    #   emsarray (setup.cfg)
+    #   xarray
 xyzservices==2023.7.0
     # via bokeh
 zict==3.0.0

--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -8,3 +8,6 @@ Next release (in development)
 * Fix an error when creating a transect plot that does not intersect the model geometry.
   Previously this would raise a cryptic error, now it returns an empty transect dataset
   (:issue:`119`, :pr:`120`).
+* Drop dependency on importlib_metadata.
+  This was only required to support Python 3.8, which was dropped in a previous release
+  (:issue:`122`, :pr:`125`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ module = [
 	"cfunits.*",
 	"cryptography.*",
 	"geojson.*",
-	"importlib_metadata.*",
 	"matplotlib.*",
 	"netCDF4.*",
 	"pooch.*",

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ install_requires =
 	# versions, but this would need testing
 	bottleneck >=1.3
 	geojson >=2.5.0
-	importlib_metadata >=4.0.0
 	netcdf4 >=1.5.3
 	numpy >=1.22.0
 	packaging >=21.3

--- a/src/emsarray/conventions/_registry.py
+++ b/src/emsarray/conventions/_registry.py
@@ -5,18 +5,13 @@ import sys
 import warnings
 from contextlib import suppress
 from functools import cached_property
+from importlib import metadata
 from itertools import chain
 from typing import Iterable, List, Optional, Tuple, Type
 
 import xarray
 
 from ._base import Convention
-
-if sys.version_info >= (3, 10):
-    from importlib import metadata
-else:
-    import importlib_metadata as metadata
-
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +147,12 @@ def entry_point_conventions() -> Iterable[Type[Convention]]:
         ('emsarray.formats', True),
     ]
     for group, deprecated in groups:
-        for entry_point in metadata.entry_points(group=group):
+        if sys.version_info >= (3, 10):
+            entry_points = metadata.entry_points(group=group)
+        else:
+            entry_points = metadata.entry_points().get(group, [])
+
+        for entry_point in entry_points:
             if deprecated:
                 warnings.warn(
                     '`emsarray.formats` entrypoint has been renamed to `emsarray.conventions`. '


### PR DESCRIPTION
This was only required to support Python 3.8 and below, which was dropped recently. Some small shenanigans were required to support Python 3.9. Dask still depends on importib_metadata so it will still be installed regardless in most circumstances.