### PR TITLE
Expand more functions that accept DataArrayOrName

### DIFF
--- a/docs/api/types.rst
+++ b/docs/api/types.rst
@@ -1,9 +1,6 @@
-.. module:: emsarray.types
-
 ==============
 emsarray.types
 ==============
 
 .. automodule:: emsarray.types
-   :noindex:
    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ napoleon_preprocess_types = True
 napoleon_type_aliases = {
     'xarray.core.dataset.Dataset': ':class:`~xarray.Dataset',
     'xarray.core.dataarray.DataArray': ':class:`~xarray.DataArray',
+    'DataArrayOrName': ':data:`data array or name <emsarray.types.DataArrayOrName>`',
 }
 
 

--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -30,3 +30,6 @@ Next release (in development)
   (:pr:`137`).
 * Lint Python code in `docs/` and `scripts/`
   (:pr:`141`).
+* Add :func:`emsarray.utils.name_to_data_array()` and :func:`~emsarray.utils.data_array_to_name()` functions.
+  Allow more functions to interchangeably take either a data array or the name of a data array
+  (:pr:`142`).

--- a/src/emsarray/transect.py
+++ b/src/emsarray/transect.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Hashable, Iterable
+from collections.abc import Iterable
 from functools import cached_property
 from typing import Any, Callable, Generic, Optional, Union, cast
 
@@ -18,8 +18,8 @@ from matplotlib.ticker import EngFormatter, Formatter
 
 from emsarray.conventions import Convention, Index
 from emsarray.plot import _requires_plot, make_plot_title
-from emsarray.types import Landmark
-from emsarray.utils import move_dimensions_to_end
+from emsarray.types import DataArrayOrName, Landmark
+from emsarray.utils import move_dimensions_to_end, name_to_data_array
 
 # Useful for calculating distances in a AzimuthalEquidistant projection
 # centred on some point:
@@ -116,13 +116,13 @@ class Transect:
         self,
         dataset: xarray.Dataset,
         line: shapely.LineString,
-        depth: Optional[Union[Hashable, xarray.DataArray]] = None,
+        depth: Optional[DataArrayOrName] = None,
     ):
         self.dataset = dataset
         self.convention = dataset.ems
         self.line = line
         if depth is not None:
-            self.depth = self.convention._get_data_array(depth)
+            self.depth = name_to_data_array(dataset, depth)
         else:
             self.depth = self.convention.depth_coordinate
 

--- a/src/emsarray/types.py
+++ b/src/emsarray/types.py
@@ -3,9 +3,11 @@ A collection of descriptive type aliases used across the library.
 """
 
 import os
+from collections.abc import Hashable
 from typing import Union
 
 import shapely
+import xarray
 
 #: Something that can be used as a path.
 Pathish = Union[os.PathLike, str]
@@ -17,3 +19,6 @@ Bounds = tuple[float, float, float, float]
 #: A landmark for a plot.
 #: This is a tuple of the landmark name and and its location.
 Landmark = tuple[str, shapely.Point]
+
+#: Either an :class:`xarray.DataArray`, or the name of a data array in a dataset.
+DataArrayOrName = Union[Hashable, xarray.DataArray]

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -43,12 +43,6 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
     def check_dataset(cls, dataset: xarray.Dataset) -> Optional[int]:
         return None
 
-    def _get_data_array(self, data_array_or_name) -> xarray.DataArray:
-        if isinstance(data_array_or_name, str):
-            return self.dataset[data_array_or_name]
-        else:
-            return data_array_or_name
-
     @cached_property
     def shape(self) -> tuple[int, int]:
         y, x = map(int, self.dataset['botz'].shape)

--- a/tests/test_utils_data_array_getters.py
+++ b/tests/test_utils_data_array_getters.py
@@ -1,0 +1,98 @@
+import numpy
+import pandas
+import pytest
+import xarray
+import xarray.testing
+
+from emsarray.utils import data_array_to_name, name_to_data_array
+
+
+def _make_dataset():
+    grid = xarray.DataArray(
+        data=numpy.arange(5 * 7).reshape(5, 7),
+        dims=['x', 'y'],
+    )
+    time = xarray.DataArray(
+        data=pandas.date_range("2024-07-08", periods=3),
+        dims=['t'],
+    )
+    dataset = xarray.Dataset({'grid': grid, 'time': time})
+    return dataset
+
+
+def test_name_to_data_array_name():
+    dataset = _make_dataset()
+    xarray.testing.assert_equal(
+        name_to_data_array(dataset, 'grid'),
+        dataset['grid'])
+    xarray.testing.assert_equal(
+        name_to_data_array(dataset, 'time'),
+        dataset['time'])
+
+
+def test_name_to_data_array_missing_name():
+    dataset = _make_dataset()
+    name = 'missing'
+    with pytest.raises(ValueError, match=f"Data array {name!r} is not in the dataset"):
+        name_to_data_array(dataset, name),
+
+
+def test_name_to_data_array_matching_data_array():
+    dataset = _make_dataset()
+    xarray.testing.assert_equal(
+        name_to_data_array(dataset, dataset['grid']),
+        dataset['grid'])
+    xarray.testing.assert_equal(
+        name_to_data_array(dataset, dataset['time']),
+        dataset['time'])
+
+
+def test_name_to_data_array_mismatched_dimensions():
+    dataset = _make_dataset()
+    # These dimensions are swapped so incorrect
+    data_array = xarray.DataArray(data=numpy.arange(5 * 7).reshape(5, 7), dims=['y', 'x'])
+    with pytest.raises(ValueError, match="Dimension mismatch between dataset and data array"):
+        name_to_data_array(dataset, data_array),
+
+
+def test_data_array_to_name_name():
+    dataset = _make_dataset()
+    assert data_array_to_name(dataset, 'grid') == 'grid'
+    assert data_array_to_name(dataset, 'time') == 'time'
+
+
+def test_data_array_to_name_no_name():
+    dataset = _make_dataset()
+    name = 'missing'
+    with pytest.raises(ValueError, match=f"Data array {name!r} is not in the dataset"):
+        data_array_to_name(dataset, name)
+
+
+def test_data_array_to_name_matching_data_array():
+    dataset = _make_dataset()
+    assert data_array_to_name(dataset, dataset['grid']) == 'grid'
+    assert data_array_to_name(dataset, dataset['time']) == 'time'
+
+
+def test_data_array_to_name_unnamed_data_array():
+    dataset = _make_dataset()
+    data_array = xarray.DataArray(data=numpy.arange(5 * 7).reshape(5, 7), dims=['x', 'y'])
+    with pytest.raises(ValueError, match="Data array has no name"):
+        data_array_to_name(dataset, data_array)
+
+
+def test_data_array_to_name_missing_data_array():
+    dataset = _make_dataset()
+    name = 'missing'
+    data_array = xarray.DataArray(data=numpy.arange(5 * 7).reshape(5, 7), dims=['x', 'y'], name=name)
+    with pytest.raises(ValueError, match=f"Dataset does not have a data array named {name!r}"):
+        data_array_to_name(dataset, data_array)
+
+
+def test_data_array_to_name_mismatched_dimensions():
+    dataset = _make_dataset()
+    # These dimensions are swapped so incorrect
+    name = 'grid'
+    data_array = xarray.DataArray(data=numpy.arange(5 * 7).reshape(5, 7), dims=['y', 'x'], name=name)
+    with pytest.raises(ValueError, match="Dimension mismatch between dataset and data array"):
+        data_array_to_name(dataset, data_array)


### PR DESCRIPTION
Two new functions `emsarray.utils.name_to_data_array` and `emsarray.utils.data_array_to_name` have been added to accomplish this. `Convention._get_data_array()` has been deprecaterd in favour of `name_to_data_array`.

WIP, still needs some tests for the new functions.