### PR TITLE
Consolidate depth coordinate methods

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -33,3 +33,4 @@ Next release (in development)
 * Add :func:`emsarray.utils.name_to_data_array()` and :func:`~emsarray.utils.data_array_to_name()` functions.
   Allow more functions to interchangeably take either a data array or the name of a data array
   (:pr:`142`).
+* Add :attr:`.Convention.depth_coordinates` and :meth:`.Convention.get_depth_coordinate_for_data_array()`. Deprecate functions :meth:`.Convention.get_depth_name()`, :meth:`.Convention.get_all_depth_names()`, and :meth:`Convention.get_time_name()`. Remove deprecated functions ``Convention.get_depths()`` and ``Convention.get_times()`` (:pr:`143`).

--- a/src/emsarray/cli/commands/extract_points.py
+++ b/src/emsarray/cli/commands/extract_points.py
@@ -6,6 +6,7 @@ import pandas
 
 import emsarray
 from emsarray.cli import BaseCommand, CommandException
+from emsarray.exceptions import NoSuchCoordinateError
 from emsarray.operations import point_extraction
 from emsarray.utils import to_netcdf_with_fixes
 
@@ -79,8 +80,8 @@ class Command(BaseCommand):
                 f"{rows.head()}\n"
                 f"(total rows: {len(rows)})")
         try:
-            time_name = dataset.ems.get_time_name()
-        except KeyError:
+            time_name = dataset.ems.time_coordinate.name
+        except NoSuchCoordinateError:
             time_name = None
 
         to_netcdf_with_fixes(

--- a/src/emsarray/conventions/_base.py
+++ b/src/emsarray/conventions/_base.py
@@ -478,50 +478,6 @@ class Convention(abc.ABC, Generic[GridKind, Index]):
         """
         return [c.name for c in self.depth_coordinates]
 
-    @utils.deprecated(
-        (
-            "Convention.get_depths() is deprecated. "
-            "Use Convention.depth_coordinate.values instead."
-        ),
-        DeprecationWarning,
-    )
-    def get_depths(self) -> numpy.ndarray:
-        """Get the depth of each vertical layer in this dataset.
-
-        .. deprecated:: 0.5.0
-            This method is replaced by
-            :attr:`Convention.depth_coordinate.values <Convention.depth_coordinate>`.
-
-        Returns
-        -------
-        :class:`numpy.ndarray`
-            An array of depths, one per vertical layer in the dataset.
-        """
-        return cast(numpy.ndarray, self.depth_coordinate.values)
-
-    @utils.deprecated(
-        (
-            "Convention.get_times() is deprecated. "
-            "Use Convention.time_coordinate.values instead."
-        ),
-        DeprecationWarning,
-    )
-    def get_times(self) -> numpy.ndarray:
-        """Get all timesteps in this dataset.
-
-        .. deprecated:: 0.5.0
-            This method is replaced by
-            :attr:`Convention.time_coordinate.values <Convention.time_coordinate>`.
-
-        Returns
-        -------
-        :class:`numpy.ndarray`
-            An array of datetimes.
-            The datetimes will be whatever native format the dataset uses,
-            likely :class:`numpy.datetime64`.
-        """
-        return cast(numpy.ndarray, self.time_coordinate.values)
-
     @abc.abstractmethod
     def ravel_index(self, index: Index) -> int:
         """Convert a convention native index to a linear index.

--- a/src/emsarray/conventions/shoc.py
+++ b/src/emsarray/conventions/shoc.py
@@ -48,24 +48,30 @@ class ShocStandard(ArakawaC):
         ArakawaCGridKind.node: ('y_grid', 'x_grid'),
     }
 
-    def get_depth_name(self) -> Hashable:
+    @cached_property
+    def depth_coordinate(self) -> xarray.DataArray:
         name = 'z_centre'
-        if name not in self.dataset.variables:
+        try:
+            return self.dataset[name]
+        except KeyError:
             raise NoSuchCoordinateError(
                 f"SHOC dataset did not have expected depth coordinate {name!r}")
-        return name
 
-    def get_all_depth_names(self) -> list[Hashable]:
-        return [
-            name for name in ['z_centre', 'z_grid']
-            if name in self.dataset.variables]
+    @cached_property
+    def depth_coordinates(self) -> tuple[xarray.DataArray, ...]:
+        names = ['z_centre', 'z_grid']
+        return tuple(
+            self.dataset[name] for name in names
+            if name in self.dataset.variables)
 
-    def get_time_name(self) -> Hashable:
+    @cached_property
+    def time_coordinate(self) -> xarray.DataArray:
         name = 't'
-        if name not in self.dataset.variables:
+        try:
+            return self.dataset[name]
+        except KeyError:
             raise NoSuchCoordinateError(
                 f"SHOC dataset did not have expected time coordinate {name!r}")
-        return name
 
     def drop_geometry(self) -> xarray.Dataset:
         dataset = super().drop_geometry()
@@ -109,23 +115,27 @@ class ShocSimple(CFGrid2D):
             return None
         return Specificity.HIGH
 
-    def get_time_name(self) -> Hashable:
-        name = 'time'
-        if name not in self.dataset.variables:
-            raise NoSuchCoordinateError(
-                f"SHOC dataset did not have expected time coordinate {name!r}")
-        return name
-
-    def get_depth_name(self) -> Hashable:
+    @cached_property
+    def depth_coordinate(self) -> xarray.DataArray:
         name = 'zc'
-        if name not in self.dataset.variables:
+        try:
+            return self.dataset[name]
+        except KeyError:
             raise NoSuchCoordinateError(
                 f"SHOC dataset did not have expected depth coordinate {name!r}")
-        return name
 
-    def get_all_depth_names(self) -> list[Hashable]:
-        name = 'zc'
-        if name in self.dataset.variables:
-            return [name]
-        else:
-            return []
+    @cached_property
+    def depth_coordinates(self) -> tuple[xarray.DataArray, ...]:
+        names = ['zc']
+        return tuple(
+            self.dataset[name] for name in names
+            if name in self.dataset.variables)
+
+    @cached_property
+    def time_coordinate(self) -> xarray.DataArray:
+        name = 'time'
+        try:
+            return self.dataset[name]
+        except KeyError:
+            raise NoSuchCoordinateError(
+                f"SHOC dataset did not have expected time coordinate {name!r}")

--- a/src/emsarray/operations/depth.py
+++ b/src/emsarray/operations/depth.py
@@ -25,16 +25,15 @@ def ocean_floor(
 
     Parameters
     ----------
-    dataset
+    dataset : xarray.Dataset
         The dataset to reduce.
     depth_coordinates : iterable of DataArrayOrName
         The depth coordinate variables.
-        For supported conventions, use :meth:`.Convention.get_all_depth_names()`.
+        For supported conventions, use :meth:`.Convention.depth_coordinates()`.
     non_spatial_variables : iterable of DataArrayOrName
-        Optional.
         A list of any non-spatial coordinate variables, such as time.
         The ocean floor is assumed to be static across non-spatial dimensions.
-        For supported conventions, use :meth:`.Convention.get_time_name()`.
+        For supported conventions, use :meth:`.Convention.time_coordinate`.
 
     Returns
     -------
@@ -75,7 +74,7 @@ def ocean_floor(
 
         >>> operations.ocean_floor(
         ...     big_dataset['temp'].isel(record=0).to_dataset(),
-        ...     depth_coordinates=big_dataset.ems.get_all_depth_names())
+        ...     depth_coordinates=big_dataset.ems.depth_coordinates))
         <xarray.Dataset>
         Dimensions:  (y: 5, x: 5)
         Coordinates:
@@ -88,7 +87,7 @@ def ocean_floor(
     See Also
     --------
     :meth:`.Convention.ocean_floor`
-    :meth:`.Convention.get_all_depth_names`
+    :meth:`.Convention.depth_coordinates`
     :func:`.normalize_depth_variables`
     :func:`.utils.extract_vars`
     """
@@ -199,7 +198,7 @@ def _find_ocean_floor_indices(
 
 def normalize_depth_variables(
     dataset: xarray.Dataset,
-    depth_variables: Iterable[DataArrayOrName],
+    depth_coordinates: Iterable[DataArrayOrName],
     *,
     positive_down: Optional[bool] = None,
     deep_to_shallow: Optional[bool] = None,
@@ -219,7 +218,7 @@ def normalize_depth_variables(
     ----------
     dataset : xarray.Dataset
         The dataset to normalize
-    depth_variables : iterable of DataArrayOrName
+    depth_coordinates : iterable of DataArrayOrName
         The depth coordinate variables.
     positive_down : bool, optional
         If True, positive values will indicate depth below the surface.
@@ -238,10 +237,10 @@ def normalize_depth_variables(
     See Also
     --------
     :meth:`.Convention.normalize_depth_variables`
-    :meth:`.Convention.get_all_depth_names`
+    :meth:`.Convention.depth_coordinates`
     """
     new_dataset = dataset.copy()
-    for variable in depth_variables:
+    for variable in depth_coordinates:
         variable = utils.name_to_data_array(dataset, variable)
         name = variable.name
         if len(variable.dims) != 1:

--- a/src/emsarray/transect.py
+++ b/src/emsarray/transect.py
@@ -57,7 +57,8 @@ def plot(
         Passed to :meth:`Transect.plot_on_figure()`.
     """
     figure = pyplot.figure(layout="constrained", figsize=figsize)
-    transect = Transect(dataset, line)
+    depth_coordinate = dataset.ems.get_depth_coordinate_for_data_array(data_array)
+    transect = Transect(dataset, line, depth=depth_coordinate)
     transect.plot_on_figure(figure, data_array, **kwargs)
     pyplot.show()
     return figure

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -136,18 +136,19 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
         return masking.mask_grid_dataset(self.dataset, clip_mask, work_dir)
 
 
-def test_get_time_name(datasets: pathlib.Path) -> None:
+def test_time_coordinate(datasets: pathlib.Path) -> None:
     dataset = xarray.open_dataset(datasets / 'times.nc')
     SimpleConvention(dataset).bind()
-    assert dataset.ems.get_time_name() == 'time'
-    xarray.testing.assert_equal(dataset.ems.time_coordinate, dataset['time'])
+    time_coordinate = dataset.ems.time_coordinate
+    assert time_coordinate.name == 'time'
+    xarray.testing.assert_equal(time_coordinate, dataset['time'])
 
 
-def test_get_time_name_missing() -> None:
+def test_time_coordinate_missing() -> None:
     dataset = xarray.Dataset()
     SimpleConvention(dataset).bind()
     with pytest.raises(NoSuchCoordinateError):
-        dataset.ems.get_time_name()
+        dataset.ems.time_coordinate
 
 
 @pytest.mark.parametrize('attrs', [
@@ -156,20 +157,20 @@ def test_get_time_name_missing() -> None:
     {'standard_name': 'depth'},
     {'axis': 'Z'},
 ], ids=lambda a: '{}:{}'.format(*next(iter(a.items()))))
-def test_get_depth_name(attrs: dict) -> None:
+def test_depth_coordinate(attrs: dict) -> None:
     dataset = xarray.Dataset({
         'name': (['dim'], [0, 1, 2], attrs),
     })
     SimpleConvention(dataset).bind()
-    assert dataset.ems.get_depth_name() == 'name'
+    assert dataset.ems.depth_coordinate.name == 'name'
     xarray.testing.assert_equal(dataset.ems.depth_coordinate, dataset['name'])
 
 
-def test_get_depth_name_missing() -> None:
+def test_depth_coordinate_missing() -> None:
     dataset = xarray.Dataset()
     SimpleConvention(dataset).bind()
     with pytest.raises(NoSuchCoordinateError):
-        dataset.ems.get_depth_name()
+        dataset.ems.depth_coordinate
 
 
 @pytest.mark.parametrize('include_time', [True, False])

--- a/tests/conventions/test_cfgrid1d.py
+++ b/tests/conventions/test_cfgrid1d.py
@@ -238,8 +238,8 @@ def test_manual_coordinate_names():
 
 def test_varnames():
     dataset = make_dataset(width=11, height=7, depth=5)
-    assert dataset.ems.get_depth_name() == 'depth'
-    assert dataset.ems.get_time_name() == 'time'
+    assert dataset.ems.depth_coordinate.name == 'depth'
+    assert dataset.ems.time_coordinate.name == 'time'
 
 
 def test_polygons_no_bounds():

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -168,19 +168,18 @@ def test_make_dataset():
 
 def test_varnames():
     dataset = make_dataset(j_size=10, i_size=10)
-    assert dataset.ems.get_depth_name() == 'zc'
-    assert dataset.ems.get_all_depth_names() == ['zc']
-    assert dataset.ems.get_time_name() == 'time'
+    assert dataset.ems.depth_coordinate.name == 'zc'
+    assert {c.name for c in dataset.ems.depth_coordinates} == {'zc'}
+    assert dataset.ems.time_coordinate.name == 'time'
 
 
 def test_no_depth_coordinate():
     dataset = make_dataset(j_size=10, i_size=10)
     dataset = dataset.isel({'k': -1}, drop=True)
-    print(dataset)
 
-    assert dataset.ems.get_all_depth_names() == []
+    assert dataset.ems.depth_coordinates == ()
     with pytest.raises(NoSuchCoordinateError):
-        dataset.ems.get_depth_name()
+        dataset.ems.depth_coordinate
 
 
 @pytest.mark.parametrize(

--- a/tests/conventions/test_shoc_standard.py
+++ b/tests/conventions/test_shoc_standard.py
@@ -218,9 +218,9 @@ def test_make_dataset():
 
 def test_varnames():
     dataset = make_dataset(j_size=10, i_size=10)
-    assert dataset.ems.get_depth_name() == 'z_centre'
-    assert dataset.ems.get_all_depth_names() == ['z_centre', 'z_grid']
-    assert dataset.ems.get_time_name() == 't'
+    assert dataset.ems.depth_coordinate.name == 'z_centre'
+    assert {c.name for c in dataset.ems.depth_coordinates} == {'z_centre', 'z_grid'}
+    assert dataset.ems.time_coordinate.name == 't'
 
 
 def test_polygons():

--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -347,9 +347,9 @@ def test_make_dataset():
 
 def test_varnames():
     dataset = make_dataset(width=3)
-    assert dataset.ems.get_depth_name() == 'Mesh2_layers'
-    assert dataset.ems.get_all_depth_names() == ['Mesh2_layers']
-    assert dataset.ems.get_time_name() == 't'
+    assert dataset.ems.depth_coordinate.name == 'Mesh2_layers'
+    assert {c.name for c in dataset.ems.depth_coordinates} == {'Mesh2_layers'}
+    assert dataset.ems.time_coordinate.name == 't'
 
 
 def test_polygons():

--- a/tests/operations/depth/test_ocean_floor.py
+++ b/tests/operations/depth/test_ocean_floor.py
@@ -68,8 +68,8 @@ def test_ocean_floor_from_files(name):
     floored = dataset.ems.ocean_floor()
 
     depth_dimensions = {
-        dataset.variables[name].dims[0]
-        for name in dataset.ems.get_all_depth_names()
+        coordinate.dims[0]
+        for coordinate in dataset.ems.depth_coordinates
     }
     original_dimensions = set(dataset.dims)
     floored_dimensions = set(floored.dims)


### PR DESCRIPTION
As per #140, there are far too many methods that deal with depth coordinates. Since #142 it is possible to use either a variable or its name interchangeably in most methods, making one of `Convention.depth_coordinate` or `Convention.get_depth_name()` et al superfluous. This PR drops `Convention.get_depth_name()` and similar methods in preference of using the coordinate variables directly.

Closes https://github.com/csiro-coasts/emsarray/issues/138, https://github.com/csiro-coasts/emsarray/issues/140