### PR TITLE
Generate a fan triangulation for convex polygons

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -4,3 +4,5 @@ Next release (in development)
 
 * Fix invalid geometry being generated for 'river' cells
   in CFGrid2D datasets with no cell bounds (:pr:`154`).
+* Improved speed of triangulation for convex polygons
+  (:pr:`151`).


### PR DESCRIPTION
The ear clipping method is correct for all polygons, but slow. For convex polygons a fan triangulation is much quicker. Most polygons will be convex. For an example dataset this sped up triangulation on my machine from around 6 seconds to 1 second.