### PR TITLE
Fix error in tests with shapely 2.0.5

### DIFF
--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -48,8 +48,9 @@ def test_add_landmarks():
 
     assert len(landmarks) == len(axes.texts)
     for landmark, text in zip(landmarks, axes.texts):
-        assert text.get_text() == landmark[0]
-        assert text.xy == landmark[1].coords.xy
+        title, point = landmark
+        assert text.get_text() == title
+        assert text.xy == (point.x, point.y)
 
 
 @pytest.mark.mpl_image_compare


### PR DESCRIPTION
shapely.Point.coords.xy changed its return type to be consistent with all other geometry coords.xy return types, but we were relying on the previous behaviour.