### PR TITLE
Fix generated bounds for 'river' cells in CFGrid2D datasets

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -2,4 +2,5 @@
 Next release (in development)
 =============================
 
-* ...
+* Fix invalid geometry being generated for 'river' cells
+  in CFGrid2D datasets with no cell bounds (:pr:`154`).


### PR DESCRIPTION
Some `CFGrid2D` datasets contain 'river' geometry - single cell wide stretches surrounded by `nan`s. CFGrid2D datasets can contain cell bounds, but in instances where the dataset does not contain cell bounds the polygons generated by emsarray were invalid along river cells.

Example of a 'river' geometry with cell bounds. Red circles are the cell centres described by the longitude/latitude variables. Blue polygons are the cell geometry described by the cell bounds:
![river-with-bounds](https://github.com/user-attachments/assets/ae3032ef-9784-4303-bfdd-64cc4d981522)

Without bounds, emsarray previously generated geometry that looked like. Red circles are the cell centres described by the longitude/latitude variables. Blue polygons are the polygons constructed by emsarray. The polygons extending along the river are invalid as they contain multiple overlapping points, and in total describe a line segment not a polygon:
![river-without-bounds-old](https://github.com/user-attachments/assets/c9c93c3b-928a-4ddd-bb18-1ced76741b7b)

For a real world example, consider the following river track: 
![tasse](https://github.com/user-attachments/assets/4b3f6181-7ba0-4006-aa39-3a1b94abc67f)

When reconstructing geometry emsarray now does not attempt to create geometry for 'river' cells. There is no viable way of reconstructing the geometry in all cases, as the river itself could curve and vary in width. No data is lost along river cells. Data can still be queried at these indices, and other geometric properties like `Convention.face_centres` might have data:
![river-without-bounds-new](https://github.com/user-attachments/assets/e6004107-50a4-4ac4-8c58-b7261e941a98)