### PR TITLE
Test polygons are valid after constructing them

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -6,3 +6,8 @@ Next release (in development)
   in CFGrid2D datasets with no cell bounds (:pr:`154`).
 * Improved speed of triangulation for convex polygons
   (:pr:`151`).
+* Check all polygons in a dataset are valid as part of generating them.
+  This will slow down opening new datasets slightly,
+  but the trade off is worth the added security
+  after the invalid polygons found in :pr:`154`
+  (:pr:`156`).

--- a/src/emsarray/conventions/arakawa_c.py
+++ b/src/emsarray/conventions/arakawa_c.py
@@ -260,9 +260,7 @@ class ArakawaC(DimensionConvention[ArakawaCGridKind, ArakawaCIndex]):
     def pack_index(self, grid_kind: ArakawaCGridKind, indexes: Sequence[int]) -> ArakawaCIndex:
         return cast(ArakawaCIndex, (grid_kind, *indexes))
 
-    @cached_property
-    @utils.timed_func
-    def polygons(self) -> numpy.ndarray:
+    def _make_polygons(self) -> numpy.ndarray:
         # Make an array of shape (j, i, 2) of all the nodes
         grid = numpy.stack([self.node.longitude.values, self.node.latitude.values], axis=-1)
 

--- a/src/emsarray/conventions/grid.py
+++ b/src/emsarray/conventions/grid.py
@@ -408,9 +408,7 @@ class CFGrid1D(CFGrid[CFGrid1DTopology]):
 
         return Specificity.LOW
 
-    @cached_property
-    @utils.timed_func
-    def polygons(self) -> numpy.ndarray:
+    def _make_polygons(self) -> numpy.ndarray:
         lon_bounds = self.topology.longitude_bounds.values
         lat_bounds = self.topology.latitude_bounds.values
 
@@ -576,9 +574,7 @@ class CFGrid2D(CFGrid[CFGrid2DTopology]):
 
         return Specificity.LOW
 
-    @cached_property
-    @utils.timed_func
-    def polygons(self) -> numpy.ndarray:
+    def _make_polygons(self) -> numpy.ndarray:
         # Construct polygons from the bounds of the cells
         lon_bounds = self.topology.longitude_bounds.values
         lat_bounds = self.topology.latitude_bounds.values

--- a/src/emsarray/conventions/ugrid.py
+++ b/src/emsarray/conventions/ugrid.py
@@ -1076,9 +1076,7 @@ class UGrid(DimensionConvention[UGridKind, UGridIndex]):
             items.append(UGridKind.edge)
         return frozenset(items)
 
-    @cached_property
-    @utils.timed_func
-    def polygons(self) -> numpy.ndarray:
+    def _make_polygons(self) -> numpy.ndarray:
         """Generate list of Polygons"""
         # X,Y coords of each node
         topology = self.topology

--- a/src/emsarray/exceptions.py
+++ b/src/emsarray/exceptions.py
@@ -10,13 +10,19 @@ class EmsarrayError(Exception):
     """
 
 
+class EmsarrayWarning(Warning):
+    """
+    Base class for all emsarray-specific warning classes.
+    """
+
+
 class ConventionViolationError(EmsarrayError):
     """
     A dataset violates its conventions in a way that is not recoverable.
     """
 
 
-class ConventionViolationWarning(UserWarning):
+class ConventionViolationWarning(EmsarrayWarning):
     """
     A dataset violates its conventions in a way that we can handle.
     For example, an attribute has an invalid type,
@@ -29,4 +35,10 @@ class NoSuchCoordinateError(KeyError, EmsarrayError):
     Raised when a dataset does not have a particular coordinate,
     such as in :attr:`.Convention.time_coordinate` and
     :attr:`.Convention.depth_coordinate`.
+    """
+
+
+class InvalidPolygonWarning(EmsarrayWarning):
+    """
+    A polygon in a dataset was invalid or not simple.
     """

--- a/src/emsarray/operations/triangulate.py
+++ b/src/emsarray/operations/triangulate.py
@@ -147,9 +147,6 @@ def _triangulate_polygon(polygon: Polygon) -> list[tuple[Vertex, Vertex, Vertex]
     :func:`triangulate_dataset`,
     `Polygon triangulation <https://en.wikipedia.org/wiki/Polygon_triangulation>`_
     """
-    if not polygon.is_simple:
-        raise ValueError("_triangulate_polygon only supports simple polygons")
-
     # The 'ear clipping' method used below is correct for all polygons, but not
     # performant. If the polygon is convex we can use a shortcut method.
     if polygon.equals(polygon.convex_hull):
@@ -173,9 +170,6 @@ def _triangulate_polygon(polygon: Polygon) -> list[tuple[Vertex, Vertex, Vertex]
     # but for small convex polygons it is approximately linear in time.
     # Most polygons will be either squares, convex quadrilaterals, or convex
     # polygons.
-
-    # Maintain a consistent winding order
-    polygon = polygon.normalize()
 
     triangles: list[tuple[Vertex, Vertex, Vertex]] = []
     # Note that shapely polygons with n vertices will be closed, and thus have

--- a/tests/conventions/test_base.py
+++ b/tests/conventions/test_base.py
@@ -118,8 +118,7 @@ class SimpleConvention(Convention[SimpleGridKind, SimpleGridIndex]):
     def drop_geometry(self) -> xarray.Dataset:
         return self.dataset
 
-    @cached_property
-    def polygons(self) -> numpy.ndarray:
+    def _make_polygons(self) -> numpy.ndarray:
         height, width = self.shape
         # Each polygon is a box from (x, y, x+1, y+1),
         # however the polygons around the edge are masked out with None.


### PR DESCRIPTION
This came about after #154 which was generating invalid polygons which were not picked up. This PR introduces a post-processing step on the `Convention.polygons` property which checks the polygons to ensure they are valid polygons. Invalid polygons will spoil other operations so it is good to be certain.

This change effectively requires any implementing conventions to rename their `polygon` property to a `_make_polygons()` method. The base `Convention` class now includes a `polygon` property which calls this new method and post-processes the results. ~A new 'hotfix' concept is being trialled here which can adapt a Convention with a `polygon` property and without a `_make_polygons()` method to the new interface. This is novel but honestly there is only one plugin for emsarray so possibly this is unnecessary extra complications. Still, it is a problem I had been mulling over for some time and I am happy I found a workable solution if only for my own education!~

Checking for polygon validity will slow things down, but not by a huge amount. The additional safety is worth it. If this safety check becomes burdensome in the future we could consider adding a 'strict' / 'non-strict' mode which enables / disables these sorts checks. In 'non-strict' mode loading datasets would be faster but any errors in the geometry would not be picked up, potentially giving invalid results or otherwise causing errors.