### PR TITLE
Add new hotfix module to automatically handle some Convention updates

### DIFF
--- a/src/emsarray/conventions/_fixes.py
+++ b/src/emsarray/conventions/_fixes.py
@@ -1,0 +1,70 @@
+import abc
+import dataclasses
+import warnings
+from typing import Callable
+
+import numpy
+
+from emsarray.conventions._base import Convention
+
+
+@dataclasses.dataclass()
+class Hotfix:
+    hotfix_cls: type
+    implements: set[str]
+    warning: str
+
+    def apply(self, convention_cls: type[Convention]) -> type[Convention]:
+        warnings.warn(self.warning.format(convention=convention_cls.__name__))
+        patched_cls = type(convention_cls.__name__, (self.hotfix_cls, convention_cls), {})
+        abc.update_abstractmethods(patched_cls)
+        return patched_cls
+
+
+hotfixes: list[Hotfix] = []
+
+
+def register_hotfix(
+    implements: set[str],
+    warning: str,
+) -> Callable[[type], type]:
+    def decorator(hotfix_cls: type) -> type:
+        hotfixes.append(Hotfix(hotfix_cls=hotfix_cls, implements=implements, warning=warning))
+        return hotfix_cls
+    return decorator
+
+
+def hotfix_convention(convention_cls: type[Convention]) -> type[Convention]:
+    abstract_methods: frozenset[str] = getattr(convention_cls, '__abstractmethods__', frozenset())
+    if not abstract_methods:
+        return convention_cls
+
+    to_apply = []
+    for hotfix in hotfixes:
+        if hotfix.implements.issubset(abstract_methods):
+            to_apply.append(hotfix)
+            abstract_methods = abstract_methods - hotfix.implements
+
+    if abstract_methods:
+        patched = convention_cls.__abstractmethods__ - abstract_methods
+        raise Exception(
+            f"Convention {convention_cls.__module__}.{convention_cls.__qualname__} "
+            f"is missing implementations for methods {', '.join(convention_cls.__abstractmethods__)}. "
+            f"Hotfixes were unavailable for methods {', '.join(sorted(patched))}."
+        )
+
+    for hotfix in to_apply:
+        convention_cls = hotfix.apply(convention_cls)
+
+    return convention_cls
+
+
+@register_hotfix(
+    {'_make_polygons'},
+    "{convention} class implements `polygons`, which was renamed to `_make_polygons` in 0.8.0",
+)
+class MakePolygonHotfix:
+    polygons = Convention.polygons
+
+    def _make_polygons(self) -> numpy.ndarray:
+        return super().polygons  # type: ignore

--- a/src/emsarray/conventions/_registry.py
+++ b/src/emsarray/conventions/_registry.py
@@ -8,6 +8,7 @@ from itertools import chain
 import xarray
 
 from ._base import Convention
+from ._fixes import hotfix_convention
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class ConventionRegistry:
             All the :class:`~emsarray.conventions.Convention` subclasses registered
             via the ``emsarray.conventions`` entry point.
         """
-        return list(entry_point_conventions())
+        return list(hotfix_convention(c) for c in entry_point_conventions())
 
     def add_convention(self, convention: type[Convention]) -> None:
         """Register a Convention subclass with this registry.
@@ -66,7 +67,7 @@ class ConventionRegistry:
         """
         with suppress(AttributeError):
             del self.conventions
-        self.registered_conventions.append(convention)
+        self.registered_conventions.append(hotfix_convention(convention))
 
     def match_conventions(self, dataset: xarray.Dataset) -> list[tuple[type[Convention], int]]:
         """


### PR DESCRIPTION
After #156 plugins such as [emsarray-smc](https://github.com/csiro-coasts/emsarray-smc) will be broken because they no longer implement all of the required abstract methods. Ultimately the plugin should be updated to correctly implement the new interface, but until that happens it would be polite if the plugin could still be used given this is a backwards incompatible change otherwise. This pull request is a work in progress towards implementing Convention hotfixes for changes such as these.

In the case of #156 a functioning Convention subclass can be made from the previous implementation using `Convention.polygons` and some `super()` call shenanigans.

Actually getting this hotfix in place is a bit tricky. If an Abstract Base Class is not fully implemented then [an error is thrown in object.__new__ at instantiation time](https://github.com/python/cpython/blob/d359a7683e4339a3e057517ff25037aff2460353/Objects/typeobject.c#L6407-L6412). The class itself needs patching before any instances can be instantiated. Specific Convention subclasses can be instantiated in two different ways: automatically by emsarray through autodetecting the appropriate Convention subclass from all the registered conventions, and manually constructing and binding a Convention subclass to a dataset.

Doing metaclass magic isn't possible. The metaclass magic has no way of knowing whether the subclass is final or not. It could be an intermediary subclass such as [CFGrid](https://github.com/csiro-coasts/emsarray/blob/19e157498f40e82d6f29e8cf936ced7237563f38/src/emsarray/conventions/grid.py#L189C7-L189C13) which is further specialised. Patching the CFGrid class would be inappropriate as the CFGrid1D or CFGrid2D classes may provide the implementations.

One approach is to patch the class at the time the class is registered only works for automatically instantiated classes as these go through the registry. This approach has the added benefit of being backwards compatible with the existing Convention plugins which might need patching without any modification. This approach doesn't work for manually instantiated convention classes though, as the class as defined in a module has not been modified. Mutating the classes in place sounds like a bad idea.

Another approach is to add a new decorator that can modify the Convention subclass at the time the class is declared. This would effectively be the same as decorating the class with the `hotfix_convention()` method defined in this WIP pull request. A better name would have to be found in that case. The decorator could also register the convention class. This approach has the downside of needing an update to plugins in order to enable the backwards compatible fixes, which kind of negates the point at least for this round of changes, but does offer more power going forward. Also, it is the only option that actually works in all cases.