### PR TITLE
Update conda-incubator/setup-miniconda action to v3

### DIFF
--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -52,9 +52,8 @@ runs:
           hashFiles('continuous-integration/environment.yaml') }}
 
     - name: Install base Conda environment
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
-        mamba-version: "*"
         environment-file: continuous-integration/environment.yaml
         python-version: ${{ inputs.python-version }}
         channels: conda-forge


### PR DESCRIPTION
v2 started breaking because mamba was no longer being installed. Instead of debugging I'm upgrading to the latest release which includes the libmamba solver, making plain conda as fast as mamba.