### PR TITLE
Triangulation speed

### DIFF
--- a/tests/conventions/test_ugrid.py
+++ b/tests/conventions/test_ugrid.py
@@ -40,7 +40,8 @@ def make_faces(width: int, height, fill_value: int) -> tuple[numpy.ndarray, nump
 
     face_node: numpy.ndarray = numpy.ma.masked_array(
         numpy.full((total_faces, 4), fill_value, dtype=numpy.int32),
-        mask=True, fill_value=fill_value)
+        mask=numpy.full((total_faces, 4), True),
+        fill_value=fill_value)
     edge_node = numpy.zeros((total_edges, 2), dtype=numpy.int32)
 
     for row in range(1, width + 1):


### PR DESCRIPTION
Further to #151 this PR adds improvements to both polygon generation speeds and triangulation speeds. The improvements compared to 0.7.0 are huge with many datasets triangulated in under a second. For some conventions the slowest part became constructing the dataset polygons rather than the triangulation, so that has been improved as well.

The following triangulation speeds were observed on my laptop for various datasets and versions of emsarray. I only did one run per version so these numbers are not a thorough benchmark.

Dataset | Convention | Polygons | Triangles | 0.7.0 (s) | 0.8.0 (s) | #163 (s)
-- | -- | --: | --: | --: | --: | --:
gbr4 | ShocSimple | 92565 | 185130 | 18.3000 | 7.4340 | 0.5143
setas | UGrid | 10072 | 38496 | 5.9360 | 1.1820 | 0.3006
access_vt | CFGrid1D | 857960 | 1715920 | 218.0150 | 84.4070 | 4.1140
macq_extract | ShocStandard | 8083 | 16166 | 1.8460 | 1.0690 | 0.0813
austen | UGrid | 183810 | 727701 | 126.7560 | 27.7250 | 1.8460

Draft PR for now. The new private triangulation function could do with a unit test or two, although the unit tests of the public API implicitly test the private functions anyway.