### PR TITLE
Updated upload and download github actions.

### DIFF
--- a/.github/actions/build-python-package/action.yaml
+++ b/.github/actions/build-python-package/action.yaml
@@ -30,7 +30,7 @@ runs:
         pip install build
         python3 -m build
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
         path: "dist/"

--- a/.github/actions/build-python-package/action.yaml
+++ b/.github/actions/build-python-package/action.yaml
@@ -18,8 +18,8 @@ runs:
   using: composite
 
   steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -38,7 +38,7 @@ runs:
           setup.cfg
 
     - name: Fetch built emsarray package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.package-artifact-name }}
         path: "dist/"

--- a/.github/actions/environment/action.yaml
+++ b/.github/actions/environment/action.yaml
@@ -29,7 +29,7 @@ runs:
 
   steps:
       # Used for the pip cache, not for the python version
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         cache: 'pip'
         cache-dependency-path: |
@@ -44,7 +44,7 @@ runs:
         path: "dist/"
 
     - name: Cache conda packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/conda_pkgs_dir
         key:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-python-package
         id: build
         with:
@@ -39,8 +39,8 @@ jobs:
     if: startsWith(github.head_ref, 'release-')
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: conda-forge/emsarray-feedstock
           path: emsarray-feedstock
@@ -75,7 +75,7 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/environment
         with:
           python-version: ${{ matrix.python-version }}
@@ -95,14 +95,14 @@ jobs:
             --cov-report xml:coverage-${{ matrix.python-version }}.xml
 
       - name: JUnit Report
-        uses: mikepenz/action-junit-report@v3
+        uses: mikepenz/action-junit-report@v5
         if: always()
         with:
           report_paths: 'junit-py*.xml'
           check_name: "JUnit Test Report - python ${{ matrix.python-version }}, ${{ matrix.dependencies }} dependencies"
 
       - name: MPL image comparison report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: "MPL image comparison report - python ${{ matrix.python-version }}, ${{ matrix.dependencies }} dependencies"
@@ -110,7 +110,7 @@ jobs:
           # No guarantee that the test failures were due to image comparisons
           if-no-files-found: 'ignore'
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Code coverage for Python ${{ matrix.python-version }}
           path: coverage-*.xml
@@ -125,14 +125,14 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/environment
         with:
           python-version: ${{ env.python-version }}
           package-artifact-name: ${{ needs.build.outputs.artifact-name }}
 
       - name: 'mypy cache'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: '.mypy_cache'
           key: mypy-${{ runner.os }}-py${{ env.python-version }}-${{ hashFiles(format('continuous-integration/requirements-{0}.txt', env.python-version)) }}
@@ -151,7 +151,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/environment
         with:
           python-version: ${{ env.python-version }}
@@ -162,7 +162,7 @@ jobs:
           cd docs/
           sphinx-build -b dirhtml -aEW . _build/dirhtml
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: Docs
           path: docs/_build/dirhtml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Code coverage for Python ${{ matrix.python-version }}
+          name: Code coverage for Python ${{ matrix.python-version }}, ${{ matrix.dependencies }} dependencies
           path: coverage-*.xml
 
   lint:

--- a/.github/workflows/release-tags.yaml
+++ b/.github/workflows/release-tags.yaml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build-python-package
         id: build
         with:
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Fetch Python package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ needs.build.outputs.artifact-name }}
           path: "dist"


### PR DESCRIPTION
Updating github actions to resolve deprecation failures.
Link: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
Changes needed: https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md