### PR TITLE
178 shocsimpletopology can raise an error on variables without a standard name

### DIFF
--- a/src/emsarray/conventions/shoc.py
+++ b/src/emsarray/conventions/shoc.py
@@ -94,12 +94,12 @@ class ShocSimple(CFGrid2D):
             latitude = next(
                 name for name, variable in self.dataset.variables.items()
                 if variable.dims == self._dimensions
-                and variable.attrs["standard_name"] == "latitude"
+                and variable.attrs.get("standard_name", None) == "latitude"
             )
             longitude = next(
                 name for name, variable in self.dataset.variables.items()
                 if variable.dims == self._dimensions
-                and variable.attrs["standard_name"] == "longitude"
+                and variable.attrs.get("standard_name", None) == "longitude"
             )
         except StopIteration:
             raise ValueError("Could not find the necessary coordinate variables")

--- a/tests/conventions/test_cfgrid2d.py
+++ b/tests/conventions/test_cfgrid2d.py
@@ -479,6 +479,11 @@ def test_values() -> None:
     # The values should be in a specific order
     assert numpy.allclose(values, eta.values.ravel(), equal_nan=True)
 
+def test_topology_with_missing_variable_standard_name() -> None:
+    # Basic test showing no error when variable has no standard name
+    dataset = make_dataset(j_size=10, i_size=20, corner_size=5, time_size=3)
+    del dataset['botz'].attrs['standard_name']
+    dataset.ems.topology
 
 @pytest.mark.matplotlib
 def test_plot_on_figure() -> None:


### PR DESCRIPTION
- Added more error resistant way of accessing the standard_name attribute for a variable. 
- Added basic unit test to check for the error case. (currently the order of the variables in the test dataset is sufficient to raise the error without the fix)