### PR TITLE
Fix some warnings from latest xarray versions

### DIFF
--- a/tests/misc/test_xarray_timedelta_units.py
+++ b/tests/misc/test_xarray_timedelta_units.py
@@ -57,7 +57,7 @@ def test_xarray_timedelta_units_unsafe_cast(
         dataset.to_netcdf(tmp_path / "period.nc")
 
 
-@only_versions('xarray >= 2024.02.0')
+@only_versions('xarray >= 2024.02.0, < 2025.03.0')
 def test_xarray_timedelta_units_cast_runtimewarning(
     tmp_path: pathlib.Path,
 ):
@@ -69,9 +69,12 @@ def test_xarray_timedelta_units_cast_runtimewarning(
     when casting a data array with dtype timedelta64 to int16
     if it contains NaT (not a time) values.
 
+    This check was later refactored out in favour of something more robust.
+
     See also
     ========
     https://github.com/pydata/xarray/issues/9134
+    https://github.com/pydata/xarray/pull/9498
     """
     dataset = make_dataset()
     message = "Not possible to cast encoded times from dtype('int64') to dtype('int16') without overflow."

--- a/tests/operations/test_cache.py
+++ b/tests/operations/test_cache.py
@@ -212,7 +212,8 @@ def test_cache_key_with_multifile_dataset_ugrid_mesh2d(datasets: pathlib.Path):
 
     dataset_paths = [ugrid_path1, ugrid_path2]
 
-    multifile_dataset = xarray.open_mfdataset(dataset_paths, data_vars=['values'])
+    multifile_dataset = xarray.open_mfdataset(
+        dataset_paths, data_vars=['values'], compat='no_conflicts')
 
     multifile_ds_hash = hashlib.sha1()
 
@@ -230,7 +231,8 @@ def test_cache_key_with_multifile_dataset_cfgrid2d(datasets: pathlib.Path):
 
     dataset_paths = [cfgrid_path1, cfgrid_path2]
 
-    multifile_dataset = xarray.open_mfdataset(dataset_paths, data_vars=['values'])
+    multifile_dataset = xarray.open_mfdataset(
+        dataset_paths, data_vars=['values'], compat='no_conflicts')
 
     multifile_ds_hash = hashlib.sha1()
 


### PR DESCRIPTION
Nothing exciting, xarray has refactored timedelta handling yet again and has updated some defaults for open_mfdataset. This should make the latest tests pass.