### PR TITLE
Don't use Dataset.data_vars to access DataArrays in UGrid

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -12,3 +12,6 @@ Next release (in development)
 * Fixed :func:`emsarray.utils.datetime_from_np_time`
   when the system timezone is not UTC and a specific timezone is requested
   (:issue:`176`, :pr:`183`).
+* Fixed an issue with UGrid datasets when some of the mesh topology variables
+  are not present in Dataset.data_vars as they are detected as coordinate variables
+  (:issue:`159`, :pr:`188`).


### PR DESCRIPTION
Dataset.data_vars doesn't contain any coordinate variables, so looking for the node_x / node_y variables in there could lead to problems.

Unfortunately, iterating over Dataset.variables will return Variable instances not DataArray instances. The best way to iterate all DataArrays - be they coordinates or data - is to iterate as so:

```python
data_arrays = (dataset[name] for name in dataset.variables.keys())
for data_array in data_arrays:
    ...
```

Fixes #159