### PR TITLE
Load transect data frame by frame

### DIFF
--- a/docs/releases/development.rst
+++ b/docs/releases/development.rst
@@ -15,3 +15,8 @@ Next release (in development)
 * Fixed an issue with UGrid datasets when some of the mesh topology variables
   are not present in Dataset.data_vars as they are detected as coordinate variables
   (:issue:`159`, :pr:`188`).
+* Load data frame by frame when plotting a transect animation.
+  This has a backwards incompatible effect of not examining the whole data array to generate a reasonable *clim*.
+  Only the first frame is used to generate the clim to avoid loading more data than required.
+  The new clim parameter allows users to specify the data limits explicitly if this is insufficient
+  (:pr:`191`).


### PR DESCRIPTION
There is no nice way to index when taking a transect, it is essentially random access. Loading the data before indexing will make it faster, but loading the entire animation dataset can fail if remote servers have request size limits. By loading the data frame by frame we reach a middle ground: the data will still be indexed relatively quickly but remote servers won't baulk at sending half a gig of data at a time.
