### PR TITLE
Fix Cartopy docs URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,7 +89,7 @@ autodoc_default_options = {
 
 # Other documentation that we link to
 intersphinx_mapping = {
-    'cartopy': ('https://scitools.org.uk/cartopy/docs/latest/', None),
+    'cartopy': ('https://cartopy.readthedocs.io/stable/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),


### PR DESCRIPTION
The Cartopy docs are now on readthedocs. We use intersphinx for building docs that link to other projects. As the docs have been moved and there is no redirect for the `objects.inv` file our docs build was breaking. Easily fixed by updating the URL for intersphinx to the new location.

See also: https://github.com/SciTools/cartopy/pull/2558